### PR TITLE
npm license compliance

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           ruby-version: 3.2.2
           bundler-cache: true
+          working-directory: ${{ inputs.workdir }}
       - run: gem install license_finder
       - name: Ensure license compliance
         working-directory: ${{ inputs.workdir }}

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -23,4 +23,4 @@ jobs:
       - run: gem install license_finder
       - name: Ensure license compliance
         working-directory: ${{ inputs.workdir }}
-        run: license_finder --decisions_file docs/dependency_decisions.yml
+        run: license_finder --recursive --decisions_file docs/dependency_decisions.yml

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -23,4 +23,4 @@ jobs:
       - run: gem install license_finder
       - name: Ensure license compliance
         working-directory: ${{ inputs.workdir }}
-        run: license_finder
+        run: license_finder --decisions_file docs/dependency_decisions.yml

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_call:
+    inputs:
+      workdir:
+        required: false
+        type: string
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    env:
+      RAILS_ENV: test
+    steps:
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+      - uses: actions/checkout@v3
+      - run: gem install license_finder
+      - name: Ensure license compliance
+        working-directory: ${{ inputs.workdir }}
+        run: license_finder

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -13,11 +13,11 @@ jobs:
     env:
       RAILS_ENV: test
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.2
-      - uses: actions/checkout@v3
       - run: gem install license_finder
       - name: Ensure license compliance
         working-directory: ${{ inputs.workdir }}

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -23,4 +23,4 @@ jobs:
       - run: gem install license_finder
       - name: Ensure license compliance
         working-directory: ${{ inputs.workdir }}
-        run: license_finder --recursive --decisions_file docs/dependency_decisions.yml
+        run: license_finder

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -18,6 +18,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.2
+          bundler-cache: true
       - run: gem install license_finder
       - name: Ensure license compliance
         working-directory: ${{ inputs.workdir }}

--- a/.github/workflows/ruby-gem.yml
+++ b/.github/workflows/ruby-gem.yml
@@ -61,13 +61,8 @@ jobs:
         working-directory: ${{ inputs.workdir }}
         run: bundle exec rake
 
-  license-compliance:
-    uses: ./.github/workflows/license-compliance.yml
-    with:
-      workdir: "${{ inputs.workdir }}"
-
   release:
-    needs: [build, license-compliance]
+    needs: build
     runs-on: ubuntu-latest
     if: ${{ contains(github.ref, 'refs/tags/v') && contains(github.ref, inputs.package) }}
     steps:

--- a/.github/workflows/ruby-gem.yml
+++ b/.github/workflows/ruby-gem.yml
@@ -60,13 +60,14 @@ jobs:
       - name: Run the build script
         working-directory: ${{ inputs.workdir }}
         run: bundle exec rake
+
   license-compliance:
     uses: ./.github/workflows/license-compliance.yml
     with:
       workdir: "${{ inputs.workdir }}"
 
   release:
-    needs: build
+    needs: [build, license-compliance]
     runs-on: ubuntu-latest
     if: ${{ contains(github.ref, 'refs/tags/v') && contains(github.ref, inputs.package) }}
     steps:

--- a/.github/workflows/ruby-gem.yml
+++ b/.github/workflows/ruby-gem.yml
@@ -61,8 +61,13 @@ jobs:
         working-directory: ${{ inputs.workdir }}
         run: bundle exec rake
 
+  license-compliance:
+    uses: ./.github/workflows/license-compliance.yml
+    with:
+      workdir: "${{ inputs.workdir }}"
+
   release:
-    needs: build
+    needs: [build, license-compliance]
     runs-on: ubuntu-latest
     if: ${{ contains(github.ref, 'refs/tags/v') && contains(github.ref, inputs.package) }}
     steps:

--- a/.github/workflows/ruby-gem.yml
+++ b/.github/workflows/ruby-gem.yml
@@ -60,9 +60,10 @@ jobs:
       - name: Run the build script
         working-directory: ${{ inputs.workdir }}
         run: bundle exec rake
-      - name: Ensure license compliance
-        working-directory: ${{ inputs.workdir }}
-        run: bundle exec license_finder
+  license-compliance:
+    uses: ./.github/workflows/license-compliance.yml
+    with:
+      workdir: "${{ inputs.workdir }}"
 
   release:
     needs: build

--- a/.github/workflows/yarn-package.yml
+++ b/.github/workflows/yarn-package.yml
@@ -37,13 +37,9 @@ jobs:
         working-directory: ${{ inputs.workdir }}
       - run: yarn test
         working-directory: ${{ inputs.workdir }}
-  license-compliance:
-    uses: ./.github/workflows/license-compliance.yml
-    with:
-      workdir: "${{ inputs.workdir }}"
 
   release:
-    needs: [build, license-compliance]
+    needs: build
     runs-on: ubuntu-latest
     name: Release
     if: ${{ contains(github.ref, 'refs/tags/v') && contains(github.ref, github.workflow) }}

--- a/.github/workflows/yarn-package.yml
+++ b/.github/workflows/yarn-package.yml
@@ -11,6 +11,9 @@ on:
       workdir:
         required: false
         type: string
+      package:
+        required: true
+        type: string
 
 env:
   NODE_RELEASE_VERSION: "16.18.0"
@@ -47,7 +50,7 @@ jobs:
     needs: [build, license-compliance]
     runs-on: ubuntu-latest
     name: Release
-    if: ${{ contains(github.ref, 'refs/tags/v') && contains(github.ref, github.workflow) }}
+    if: ${{ contains(github.ref, 'refs/tags/v') && contains(github.ref, inputs.package) }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node ${{ env.NODE_RELEASE_VERSION }}

--- a/.github/workflows/yarn-package.yml
+++ b/.github/workflows/yarn-package.yml
@@ -38,8 +38,13 @@ jobs:
       - run: yarn test
         working-directory: ${{ inputs.workdir }}
 
+  license-compliance:
+    uses: ./.github/workflows/license-compliance.yml
+    with:
+      workdir: "${{ inputs.workdir }}"
+
   release:
-    needs: build
+    needs: [build, license-compliance]
     runs-on: ubuntu-latest
     name: Release
     if: ${{ contains(github.ref, 'refs/tags/v') && contains(github.ref, github.workflow) }}

--- a/.github/workflows/yarn-package.yml
+++ b/.github/workflows/yarn-package.yml
@@ -43,7 +43,7 @@ jobs:
       workdir: "${{ inputs.workdir }}"
 
   release:
-    needs: build
+    needs: [build, license-compliance]
     runs-on: ubuntu-latest
     name: Release
     if: ${{ contains(github.ref, 'refs/tags/v') && contains(github.ref, github.workflow) }}

--- a/.github/workflows/yarn-package.yml
+++ b/.github/workflows/yarn-package.yml
@@ -37,6 +37,10 @@ jobs:
         working-directory: ${{ inputs.workdir }}
       - run: yarn test
         working-directory: ${{ inputs.workdir }}
+  license-compliance:
+    uses: ./.github/workflows/license-compliance.yml
+    with:
+      workdir: "${{ inputs.workdir }}"
 
   release:
     needs: build


### PR DESCRIPTION
- Extract license-compliance workflow
- Checkout before build
- Depend on license-compliance for release
- Cache bundled gems
- Bundle from workdir
- Let license-compliance run as a separate workflow
- Run license finder recursively
- Back to one license_compliance per project because it needs the installed deps
- Add package input to yarn package workflow
