### PR TITLE
Make secrets.rubygems_api_key optional in ruby

### DIFF
--- a/.github/workflows/ruby-gem.yml
+++ b/.github/workflows/ruby-gem.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     secrets:
       rubygems_api_key:
-        required: true
+        required: false
     inputs:
       before_build:
         type: string
@@ -61,7 +61,7 @@ jobs:
   release:
     needs: [build, license-compliance]
     runs-on: ubuntu-latest
-    if: ${{ contains(github.ref, 'refs/tags/v') && contains(github.ref, inputs.package) }}
+    if: ${{ secrets.rubygems_api_key != '' && contains(github.ref, 'refs/tags/v') && contains(github.ref, inputs.package) }}
     steps:
       - uses: actions/checkout@v3
       - uses: cadwallion/publish-rubygems-action@master

--- a/docs/ruby-gem.md
+++ b/docs/ruby-gem.md
@@ -44,6 +44,6 @@ jobs:
 
 The following secrets are expected to be available:
 
-| **Secret**       | **Required** |
-| ---------------- | ------------ |
-| rubygems_api_key | true         |
+| **Secret**       | **Required**       |
+| ---------------- | ------------------ |
+| rubygems_api_key | true, if releasing |


### PR DESCRIPTION
These secrets are only used when the gem is supposed to be released to rubygems