### PR TITLE
[FVR-299] Start inheriting Power Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,12 @@
 {
-  "extends": ["config:base", "group:allNonMajor"],
+  "extends": [
+    "group:allNonMajor",
+    "github>powerhome/renovate-config"
+  ],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true
   },
-  "labels": ["dependencies"],
-  "timezone": "America/New_York",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],

--- a/renovate.json
+++ b/renovate.json
@@ -9,15 +9,24 @@
   },
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
     },
     {
-      "matchDepTypes": ["devDependencies"],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
       "automerge": true
     },
     {
-      "matchPackageNames": ["rubocop"],
+      "matchPackageNames": [
+        "rubocop"
+      ],
       "allowedVersions": "< 1.45.0"
     }
   ]


### PR DESCRIPTION
Part of [FVR-299](https://runway.powerhrg.com/backlog_items/FVR-299)

This will ensure Power-standard Renovate config options like tagging Renovate PRs with the 'dependencies' label, ignoring updates to the `.github/workflows/stale.yml` file, and other important Renovate config options are respected in this repository.

Similar to powerhome/power-tools#304, this includes removing the config entry to tag PRs with 'dependencies', as this will be inherited from the parent config, as well as the duplicate timezone definition. It also expands arrays to match other Renovate configs for consistency, without any content changes.