### PR TITLE
GLC-2100: Add agentic-pr-review shared composite action

### DIFF
--- a/.github/actions/agentic-pr-review/README.md
+++ b/.github/actions/agentic-pr-review/README.md
@@ -1,0 +1,100 @@
+# Agentic PR Review
+
+Runs a headless review agent against the **merge-base diff** for a pull request, then posts the result as a **GitHub PR review** (summary plus optional inline comments). The default provider is **Cursor** (`agent` CLI with `CURSOR_API_KEY`).
+
+## What it does
+
+1. Creates an installation token for a **GitHub App** (needs repository scopes contents:read and pull_requests:read_write).
+2. Loads PR metadata via the GitHub API to resolve the PR base/head refs.
+3. Checks out the PR **head** ref, fetches enough history to compute the merge-base with the base branch, and writes `pr.diff` (`base...head` three-dot diff).
+4. Invokes the configured **provider** via `scripts/providers/<provider>.sh` with `prompts/review.md` plus any **additional prompt** text.
+5. Parses the agent's JSON output and posts a review on the PR head commit.
+
+Artifacts: uploads `review-agent.json` from the workspace when present (for debugging).
+
+## Inputs
+
+| Input | Required | Description |
+| --- | --- | --- |
+| `app-id` | yes | GitHub App ID used with `actions/create-github-app-token`. |
+| `private-key` | yes | GitHub App private key (PEM). |
+| `provider-api-key` | yes | Provider API key (Cursor: becomes `CURSOR_API_KEY`). |
+| `pull-request-number` | yes | PR number to review. |
+| `provider` | no | Review backend; the action resolves it via `scripts/providers/<provider>.sh` (default: `cursor`). |
+| `deepen-length` | no | Passed to `rmacklin/fetch-through-merge-base` as `deepen_length` (default: `30`). |
+| `additional-prompt` | no | Extra text appended to the review prompt after `prompts/review.md`. |
+
+## Secrets and permissions
+
+- Store **`app-id`**, **`private-key`**, and **`provider-api-key`** as repository (or org) secrets; do not commit them.
+- The calling workflow needs permission to **read** contents and **write** pull requests (for posting the review). The GitHub App installation must be allowed to clone the repo and create reviews on the target repository.
+
+## Example Usage
+
+### Review a PR from a pull request event
+
+Use this when your workflow already runs in response to a PR event and you want the action to review that PR.
+
+```yaml
+- uses: ./.github/actions/agentic-pr-review
+  with:
+    app-id: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_ID }}
+    private-key: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_PRIVATE_KEY }}
+    provider-api-key: ${{ secrets.AGENTIC_REVIEW_PROVIDER_API_KEY }}
+    pull-request-number: ${{ github.event.pull_request.number }}
+```
+
+### Review a PR and pass extra instructions
+
+Use `additional-prompt` when you want to append user-supplied context, such as a workflow input or comment body, to the base review prompt.
+
+```yaml
+- uses: ./.github/actions/agentic-pr-review
+  with:
+    app-id: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_ID }}
+    private-key: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_PRIVATE_KEY }}
+    provider-api-key: ${{ secrets.AGENTIC_REVIEW_PROVIDER_API_KEY }}
+    pull-request-number: ${{ github.event.issue.number }}
+    additional-prompt: ${{ github.event.comment.body }}
+```
+
+Use `github.event.pull_request.number` when the workflow runs on `pull_request` events. Use `github.event.issue.number` for `issue_comment` events on a pull request.
+
+### Skip ineligible pull requests before invoking the action
+
+If your workflow should avoid reviewing draft or closed pull requests, add a small skip step before invoking this action.
+
+```yaml
+- name: Skip ineligible PRs
+  id: skip_gate
+  if: |
+    (github.event.pull_request.state || github.event.issue.state) != 'open' ||
+    (github.event.pull_request.draft || github.event.issue.draft)
+  run: |
+    echo "skip=true" >> "${GITHUB_OUTPUT}"
+    echo "Skipping agentic review because the PR is not open or is draft"
+
+- uses: ./.github/actions/agentic-pr-review
+  if: steps.skip_gate.outputs.skip != 'true'
+  with:
+    app-id: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_ID }}
+    private-key: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_PRIVATE_KEY }}
+    provider-api-key: ${{ secrets.AGENTIC_REVIEW_PROVIDER_API_KEY }}
+    pull-request-number: ${{ github.event.pull_request.number }}
+```
+
+## Prompt and output
+
+- Base instructions: `prompts/review.md` (JSON-only response with `summary` and optional inline `comments`).
+- If `additional-prompt` is non-empty, it is appended under a short "Additional instructions from the PR comment" section before calling the agent.
+
+## CLI permissions
+
+### Cursor (read-only)
+
+[`config/cli-config.json`](config/cli-config.json) is copied to **`.cursor/cli-config.json`** (the [project-local CLI config](https://cursor.com/docs/cli/reference/permissions) path). It **allows** only `Read(**)` and **denies** `Shell(*)`, `Write(**)`, and `Mcp(*:*)`. Adjust if you need `WebFetch` or specific MCP tools (not included here).
+
+```bash
+mkdir -p .cursor
+cp path/to/agentic-pr-review/config/cli-config.json .cursor/cli-config.json
+```

--- a/.github/actions/agentic-pr-review/action.yml
+++ b/.github/actions/agentic-pr-review/action.yml
@@ -1,0 +1,124 @@
+name: Agentic PR review
+description: Run a headless agent on the PR diff and post a comment-only GitHub review
+
+inputs:
+  app-id:
+    description: GitHub App ID used to create an installation token
+    required: true
+  private-key:
+    description: GitHub App private key (PEM)
+    required: true
+  provider:
+    description: Review backend (supported values — cursor)
+    required: false
+    default: cursor
+  provider-api-key:
+    description: API credential for the selected provider (e.g. Cursor maps this to CURSOR_API_KEY)
+    required: true
+  pull-request-number:
+    description: Pull request number to review
+    required: true
+  deepen-length:
+    description: Passed to rmacklin/fetch-through-merge-base as deepen_length
+    required: false
+    default: "30"
+  additional-prompt:
+    description: Extra instructions appended to the review prompt (e.g. full text of an @nitro-pr-review PR comment)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Create GitHub App token
+      id: app_token
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+
+    - name: Fetch PR metadata
+      id: pr_gate
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        PR_NUMBER: ${{ inputs.pull-request-number }}
+      run: |
+        set -euo pipefail
+
+        gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2026-03-10" \
+          "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+          > pr.json
+
+        {
+          echo "base_sha=$(jq -r '.base.sha' pr.json)"
+          echo "head_sha=$(jq -r '.head.sha' pr.json)"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Check out repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        ref: ${{ steps.pr_gate.outputs.head_sha }}
+        fetch-depth: 1
+        token: ${{ steps.app_token.outputs.token }}
+
+    - name: Fetch base commit (for merge-base)
+      shell: bash
+      env:
+        BASE_SHA: ${{ steps.pr_gate.outputs.base_sha }}
+      run: git fetch --depth=1 origin "$BASE_SHA"
+
+    - name: Fetch through merge-base
+      uses: rmacklin/fetch-through-merge-base@98594af01ba0825b881902a5dcadbf87bb46d084 # v0
+      with:
+        base_ref: ${{ steps.pr_gate.outputs.base_sha }}
+        head_ref: ${{ steps.pr_gate.outputs.head_sha }}
+        deepen_length: ${{ inputs.deepen-length }}
+
+    - name: Compute PR diff
+      shell: bash
+      env:
+        BASE_SHA: ${{ steps.pr_gate.outputs.base_sha }}
+        HEAD_SHA: ${{ steps.pr_gate.outputs.head_sha }}
+      run: |
+        set -euo pipefail
+        git diff "${BASE_SHA}...${HEAD_SHA}" > "${GITHUB_WORKSPACE}/pr.diff"
+
+    - name: Run review provider
+      shell: bash
+      env:
+        PROVIDER: ${{ inputs.provider }}
+        PROVIDER_API_KEY: ${{ inputs.provider-api-key }}
+        REVIEW_JSON_PATH: ${{ github.workspace }}/review-agent.json
+        REVIEW_PROMPT_PATH: ${{ github.action_path }}/prompts/review.md
+        REVIEW_ADDITIONAL_INSTRUCTIONS: ${{ inputs.additional-prompt }}
+      run: |
+        set -euo pipefail
+
+        provider="${PROVIDER:-cursor}"
+        provider_script="${{ github.action_path }}/scripts/providers/${provider}.sh"
+
+        if [[ ! -f "${provider_script}" ]]; then
+          echo "Unknown provider: ${provider} (expected script at ${provider_script})" >&2
+          exit 1
+        fi
+
+        exec bash "${provider_script}"
+
+    - name: Upload agent review JSON
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: agentic-pr-review-json
+        path: ${{ github.workspace }}/review-agent.json
+        if-no-files-found: warn
+
+    - name: Post review to GitHub
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+        PULL_NUMBER: ${{ inputs.pull-request-number }}
+        COMMIT_SHA: ${{ steps.pr_gate.outputs.head_sha }}
+        REVIEW_JSON_PATH: ${{ github.workspace }}/review-agent.json
+      run: ruby "${{ github.action_path }}/scripts/process_review.rb"

--- a/.github/actions/agentic-pr-review/config/cli-config.json
+++ b/.github/actions/agentic-pr-review/config/cli-config.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": ["Read(**)"],
+    "deny": ["Shell(*)", "Write(**)", "Mcp(*:*)"]
+  }
+}

--- a/.github/actions/agentic-pr-review/prompts/review.md
+++ b/.github/actions/agentic-pr-review/prompts/review.md
@@ -1,0 +1,90 @@
+You are an automated pull request reviewer.
+
+## Inputs
+
+The unified diff for this PR is in the file `pr.diff` at the repository root (already present). Use it as the sole source of what changed. You may read files under the repository only if needed for context.
+
+## Hard constraints
+
+You must NOT modify any files, run git, run shell commands, or use tools that change repository state.
+
+## What to focus on
+
+Prioritize **correctness, security, reliability, and clear bugs** (including edge cases, error handling, data integrity, and unsafe patterns).
+
+Only raise a finding when the diff introduces a **concrete, likely, user- or developer-facing problem** under expected usage. Prefer silence over speculative hardening advice.
+
+**Avoid** inline comments that are primarily:
+
+- Formatting or style preferences (unless they mask real issues)
+- Subjective opinions or taste (“I would have…”)
+- Nitpicks that do not reduce risk or improve maintainability in a concrete way
+- Defensive suggestions for states that should never happen in normal operation
+- Hypothetical security concerns without a clear exploit path in this repository's actual usage model
+- Comments about acknowledged or documented tradeoffs unless the diff makes them materially worse
+
+Examples of comments to avoid:
+
+- "This could be safer" when the current behavior is an intentional workflow tradeoff
+- "Guard against this being nil / malformed" when the value is expected to be present by contract
+- Generic prompt-injection, supply-chain, or race-condition concerns without evidence that this change creates a real regression or exploitable path
+
+If you have nothing substantive to say for a line, omit it.
+
+## Severity
+
+Each inline comment must include a **severity** (exactly one of: `low`, `medium`, `high`, `critical`):
+
+- **critical** — likely data loss, security vulnerability, broken behavior in production, or severe misuse of APIs
+- **high** — probable bugs, significant regressions, important missing error handling
+- **medium** — a real, actionable problem with moderate impact; not just a suggestion or hardening idea
+- **low** — minor but still useful, non-style observations
+
+When choosing what to include, **prioritize `high` and `critical`** items in your thinking; use `low` sparingly.
+Do not emit a `medium` or `high` finding unless you can point to a plausible failure mode in expected operation.
+
+## Output format
+
+Respond with **a single JSON object only**. No markdown code fences, no text before or after the JSON.
+
+Required shape (keys and types):
+
+- `summary` (string, required, non-empty) — concise high-level review; markdown allowed inside the string.
+- `comments` (array) — optional; use an empty array if there are no inline notes.
+- Each element of `comments` is an object with:
+  - `path` (string) — repo-relative path
+  - `line` (integer) — 1-based line on PR head for a changed line
+  - `body` (string) — comment text (markdown allowed inside the string)
+  - `severity` (string) — exactly one of: `low`, `medium`, `high`, `critical`
+
+Example object (structure only; your output must be raw JSON, not wrapped in backticks):
+
+    { "summary": "…", "comments": [ { "path": "src/a.rb", "line": 10, "body": "…", "severity": "high" } ] }
+
+## Comment style
+
+For each inline comment:
+
+- Put the blocker or concern first, in 1-3 short paragraphs.
+- If you want to include an implementation suggestion, example fix, or alternate approach, put that part inside a collapsible `<details>` block.
+- Do not include a collapsible section unless there is a concrete suggestion worth showing.
+
+Example inline comment body shape:
+
+    This change can fail if `foo` is nil in normal request handling, which would raise before we build the response.
+
+    <details>
+    <summary>Implementation suggestion</summary>
+
+    Consider returning early when `foo` is missing so the endpoint keeps its existing 422 behavior.
+    </details>
+
+## Summary style
+
+The summary should be brief and non-redundant.
+
+- If there are inline comments, do **not** repeat them as a numbered or bulleted list in the summary.
+- Use the summary for overall outcome only: for example, whether the review found blocking issues, whether the diff looks sound overall, or the single highest-level concern.
+- If there are no inline comments, the summary may explain the key concern(s) directly.
+
+Output valid JSON only.

--- a/.github/actions/agentic-pr-review/scripts/agent_review_parser.rb
+++ b/.github/actions/agentic-pr-review/scripts/agent_review_parser.rb
@@ -1,0 +1,79 @@
+#!/usr/bin/env ruby
+
+require "json"
+
+class AgentReviewParser
+  MAX_INLINE_COMMENTS = 50
+  # Bump when changing review posting behavior or summary format.
+  REVIEW_POSTER_VERSION = "1.0.0"
+
+  def self.parse_file(path)
+    new(File.read(path))
+  end
+
+  def initialize(json_string)
+    @payload = JSON.parse(json_string)
+    validate_root!
+    @summary_body = build_summary_body
+    @inline_comments = build_inline_comments
+  end
+
+  attr_reader :summary_body, :inline_comments
+
+private
+
+  def validate_root!
+    raise "Review JSON root must be a JSON object" unless @payload.is_a?(Hash)
+
+    summary = @payload["summary"].to_s.strip
+    raise 'Review JSON must include a non-empty "summary" string' if summary.empty?
+  end
+
+  def build_summary_body
+    summary = @payload["summary"].to_s.strip
+    "<!-- agentic-pr-review #{REVIEW_POSTER_VERSION} -->\n\n#{summary}"
+  end
+
+  def build_inline_comments
+    raw = @payload["comments"]
+    raw = [] unless raw.is_a?(Array)
+    comments = raw.filter_map { |c| build_inline_comment(c) }
+    limit_inline_comments(comments)
+  end
+
+  def format_comment_body(severity, body)
+    s = severity.to_s.strip
+    return body if s.empty?
+
+    "**Severity: #{s}**\n\n#{body}"
+  end
+
+  def build_inline_comment(entry)
+    return nil unless entry.is_a?(Hash)
+
+    path = entry["path"].to_s.strip
+    body = entry["body"].to_s
+    line = entry["line"]
+    return nil if path.empty? || body.empty?
+    return nil if line.nil?
+
+    line_i = Integer(line, exception: false)
+    return nil if line_i.nil? || line_i < 1
+
+    {
+      "path" => path,
+      "body" => format_comment_body(entry["severity"], body),
+      "line" => line_i,
+      "side" => "RIGHT",
+    }
+  end
+
+  def limit_inline_comments(comments)
+    return comments if comments.size <= MAX_INLINE_COMMENTS
+
+    dropped = comments.size - MAX_INLINE_COMMENTS
+    warn "[process_review] #{comments.size} inline comments exceed max (#{MAX_INLINE_COMMENTS}); " \
+         "truncating to first #{MAX_INLINE_COMMENTS} (#{dropped} omitted)"
+    comments.take(MAX_INLINE_COMMENTS)
+  end
+end

--- a/.github/actions/agentic-pr-review/scripts/agent_review_parser_spec.rb
+++ b/.github/actions/agentic-pr-review/scripts/agent_review_parser_spec.rb
@@ -1,0 +1,99 @@
+#!/usr/bin/env ruby
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "rspec", "~> 3.13"
+end
+
+require "json"
+require "rspec/autorun"
+require "tempfile"
+
+require_relative "agent_review_parser"
+
+RSpec.describe AgentReviewParser do
+  describe "#summary_body" do
+    it "includes the version marker and summary text" do
+      parsed = described_class.new({ "summary" => "Hello" }.to_json)
+      expect(parsed.summary_body).to match(
+        /\A<!-- agentic-pr-review #{described_class::REVIEW_POSTER_VERSION} -->\n\nHello\z/mo
+      )
+    end
+  end
+
+  describe "#inline_comments" do
+    it "builds entries with severity prefix and metadata" do
+      json = {
+        "summary" => "S",
+        "comments" => [
+          { "path" => "a.rb", "body" => "fix", "line" => 2, "severity" => "high" },
+        ],
+      }.to_json
+      parsed = described_class.new(json)
+      expect(parsed.inline_comments.size).to eq(1)
+      c = parsed.inline_comments.first
+      expect(c["path"]).to eq("a.rb")
+      expect(c["line"]).to eq(2)
+      expect(c["side"]).to eq("RIGHT")
+      expect(c["body"]).to match(/^\*\*Severity: high\*\*/)
+      expect(c["body"]).to match(/fix\z/)
+    end
+
+    it "skips invalid comment rows" do
+      json = {
+        "summary" => "S",
+        "comments" => [
+          { "path" => "", "body" => "x", "line" => 1 },
+          { "path" => "ok.rb", "body" => "good", "line" => 1 },
+          { "path" => "bad.rb", "body" => "no line" },
+        ],
+      }.to_json
+      parsed = described_class.new(json)
+      expect(parsed.inline_comments.size).to eq(1)
+      expect(parsed.inline_comments.first["path"]).to eq("ok.rb")
+    end
+
+    it "treats non-array comments as empty" do
+      parsed = described_class.new({ "summary" => "S", "comments" => "nope" }.to_json)
+      expect(parsed.inline_comments).to be_empty
+    end
+
+    it "truncates past the max and warns on stderr" do
+      comments = (1..(described_class::MAX_INLINE_COMMENTS + 5)).map do |i|
+        { "path" => "f.rb", "body" => "c#{i}", "line" => i }
+      end
+      json = { "summary" => "S", "comments" => comments }.to_json
+      parsed = nil
+      expect do
+        parsed = described_class.new(json)
+      end.to output(/truncating/).to_stderr
+      expect(parsed.inline_comments.size).to eq(described_class::MAX_INLINE_COMMENTS)
+    end
+  end
+
+  describe ".parse_file" do
+    it "reads JSON from disk" do
+      Tempfile.create(["review", ".json"]) do |f|
+        f.write({ "summary" => "From file" }.to_json)
+        f.flush
+        parsed = described_class.parse_file(f.path)
+        expect(parsed.summary_body).to include("From file")
+      end
+    end
+  end
+
+  describe "validation" do
+    it "rejects a non-object JSON root" do
+      expect do
+        described_class.new("[1]")
+      end.to raise_error(RuntimeError, /JSON object/)
+    end
+
+    it "rejects an empty summary" do
+      expect do
+        described_class.new({ "summary" => "  " }.to_json)
+      end.to raise_error(RuntimeError, /summary/)
+    end
+  end
+end

--- a/.github/actions/agentic-pr-review/scripts/github_review_poster.rb
+++ b/.github/actions/agentic-pr-review/scripts/github_review_poster.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "net/http"
+require "uri"
+
+class GitHubReviewPoster
+  def initialize(owner:, repo:, pr_number:, commit_sha:, token:)
+    @owner = owner
+    @repo = repo
+    @pr_number = pr_number
+    @commit_sha = commit_sha
+    @token = token
+  end
+
+  def post_batch_review(summary_body, inline_comments)
+    post(
+      "/repos/#{@owner}/#{@repo}/pulls/#{@pr_number}/reviews",
+      {
+        commit_id: @commit_sha,
+        body: summary_body,
+        event: "COMMENT",
+        comments: inline_comments,
+      }
+    )
+    true
+  rescue RequestError => e
+    log_request_error("Batch review failed", e)
+    false
+  end
+
+  def post_summary_only(summary_body)
+    post(
+      "/repos/#{@owner}/#{@repo}/pulls/#{@pr_number}/reviews",
+      {
+        commit_id: @commit_sha,
+        body: summary_body,
+        event: "COMMENT",
+      }
+    )
+    true
+  rescue RequestError => e
+    log_request_error("Summary review failed", e)
+    false
+  end
+
+  def post_single_comment(comment, failure_label: "Inline comment failed")
+    post(
+      "/repos/#{@owner}/#{@repo}/pulls/#{@pr_number}/comments",
+      {
+        body: comment["body"],
+        commit_id: @commit_sha,
+        path: comment["path"],
+        line: comment["line"],
+        side: comment["side"] || "RIGHT",
+      }
+    )
+    true
+  rescue RequestError => e
+    log_request_error(failure_label, e)
+    false
+  end
+
+private
+
+  class RequestError < StandardError; end
+
+  def api_endpoint
+    base = ENV.fetch("GITHUB_API_URL", "https://api.github.com").chomp("/")
+    URI("#{base}/")
+  end
+
+  def post(path, payload)
+    uri = api_endpoint + path.delete_prefix("/")
+    request = Net::HTTP::Post.new(uri)
+    request["Authorization"] = "Bearer #{@token}"
+    request["Accept"] = "application/vnd.github+json"
+    request["X-GitHub-Api-Version"] = "2022-11-28"
+    request["User-Agent"] = "nitro-agentic-pr-review"
+    request.content_type = "application/json"
+    request.body = JSON.dump(payload)
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+      http.request(request)
+    end
+
+    return parse_response(response) if response.is_a?(Net::HTTPSuccess)
+
+    raise RequestError, format_error(response)
+  end
+
+  def parse_response(response)
+    return if response.body.to_s.empty?
+
+    JSON.parse(response.body)
+  rescue JSON::ParserError
+    response.body
+  end
+
+  def format_error(response)
+    payload = parse_response(response)
+    message =
+      if payload.is_a?(Hash)
+        details = Array(payload["errors"]).map(&:inspect)
+        [payload["message"], *details].compact.join(" | ")
+      else
+        payload.to_s
+      end
+
+    "HTTP #{response.code}: #{message}"
+  end
+
+  def log_request_error(label, error)
+    warn "[process_review] #{label}: #{error.message}"
+  end
+end

--- a/.github/actions/agentic-pr-review/scripts/github_review_poster_spec.rb
+++ b/.github/actions/agentic-pr-review/scripts/github_review_poster_spec.rb
@@ -1,0 +1,121 @@
+#!/usr/bin/env ruby
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "rspec", "~> 3.13"
+end
+
+require "json"
+require "rspec/autorun"
+
+require_relative "github_review_poster"
+
+RSpec.describe GitHubReviewPoster do
+  let(:owner) { "acme" }
+  let(:repo) { "widgets" }
+  let(:pr_number) { 42 }
+  let(:commit_sha) { "abc123" }
+  let(:token) { "secret-token" }
+
+  subject(:poster) do
+    described_class.new(
+      owner:,
+      repo:,
+      pr_number:,
+      commit_sha:,
+      token:
+    )
+  end
+
+  def build_response(klass, code:, message:, body:)
+    response = klass.new("1.1", code.to_s, message)
+    allow(response).to receive(:body).and_return(body)
+    response
+  end
+
+  def stub_post(response, host: "api.github.com", port: 443, use_ssl: true)
+    captured_request = nil
+    http = instance_double(Net::HTTP)
+    allow(http).to receive(:request) do |request|
+      captured_request = request
+      response
+    end
+
+    allow(Net::HTTP).to receive(:start).with(host, port, use_ssl:).and_yield(http)
+
+    -> { captured_request }
+  end
+
+  describe "#post_batch_review" do
+    it "posts a review with summary and inline comments" do
+      response = build_response(
+        Net::HTTPCreated,
+        code: 201,
+        message: "Created",
+        body: { id: 1 }.to_json
+      )
+      request_for = stub_post(response)
+      comments = [{ "path" => "a.rb", "line" => 7, "side" => "RIGHT", "body" => "Please fix" }]
+
+      expect(poster.post_batch_review("Summary", comments)).to eq(true)
+
+      request = request_for.call
+      expect(request.path).to eq("/repos/acme/widgets/pulls/42/reviews")
+      expect(request["Authorization"]).to eq("Bearer secret-token")
+      expect(request["Accept"]).to eq("application/vnd.github+json")
+      expect(request["X-GitHub-Api-Version"]).to eq("2022-11-28")
+      expect(request["User-Agent"]).to eq("nitro-agentic-pr-review")
+      expect(request.content_type).to eq("application/json")
+      expect(JSON.parse(request.body)).to eq(
+        "commit_id" => "abc123",
+        "body" => "Summary",
+        "event" => "COMMENT",
+        "comments" => comments
+      )
+    end
+  end
+
+  describe "#post_summary_only" do
+    it "returns false and logs the API error" do
+      response = build_response(
+        Net::HTTPUnprocessableEntity,
+        code: 422,
+        message: "Unprocessable Entity",
+        body: { message: "Validation Failed", errors: [{ "field" => "line" }] }.to_json
+      )
+      stub_post(response)
+
+      expect do
+        expect(poster.post_summary_only("Summary")).to eq(false)
+      end.to output(/Summary review failed: HTTP 422: Validation Failed/).to_stderr
+    end
+  end
+
+  describe "#post_single_comment" do
+    it "defaults side to RIGHT and posts to the comments endpoint" do
+      response = build_response(
+        Net::HTTPCreated,
+        code: 201,
+        message: "Created",
+        body: { id: 2 }.to_json
+      )
+      request_for = stub_post(response, host: "github.example.com", port: 8443, use_ssl: true)
+      comment = { "path" => "lib/test.rb", "line" => 3, "body" => "Nit: rename this" }
+      allow(ENV).to receive(:fetch).with("GITHUB_API_URL", "https://api.github.com")
+                                   .and_return("https://github.example.com:8443/api/v3")
+
+      expect(poster.post_single_comment(comment)).to eq(true)
+
+      request = request_for.call
+      expect(request.path).to eq("/api/v3/repos/acme/widgets/pulls/42/comments")
+      expect(JSON.parse(request.body)).to eq(
+        "body" => "Nit: rename this",
+        "commit_id" => "abc123",
+        "path" => "lib/test.rb",
+        "line" => 3,
+        "side" => "RIGHT"
+      )
+    end
+  end
+end

--- a/.github/actions/agentic-pr-review/scripts/process_review.rb
+++ b/.github/actions/agentic-pr-review/scripts/process_review.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+
+require_relative "agent_review_parser"
+require_relative "github_review_poster"
+
+def load_review(path)
+  AgentReviewParser.parse_file(path)
+rescue JSON::ParserError => e
+  warn "Failed to parse review JSON: #{e.message}"
+  exit 1
+rescue Errno::ENOENT => e
+  warn "Review JSON not found: #{e.message}"
+  exit 1
+rescue => e
+  warn e.message
+  exit 1
+end
+
+review_path = ENV["REVIEW_JSON_PATH"] || File.join(Dir.pwd, "review-agent.json")
+
+unless File.file?(review_path)
+  warn "Review JSON not found at #{review_path}"
+  exit 1
+end
+
+parsed = load_review(review_path)
+
+repo_full = ENV["GITHUB_REPOSITORY"].to_s
+owner, repo = repo_full.split("/", 2)
+pr_number = ENV["PULL_NUMBER"].to_s
+token = ENV["GITHUB_TOKEN"].to_s
+commit_sha = ENV["COMMIT_SHA"].to_s
+
+env_var_errors = []
+env_var_errors << "GITHUB_REPOSITORY" if repo_full.empty? || owner.to_s.empty? || repo.to_s.empty?
+env_var_errors << "PULL_NUMBER" if pr_number.empty?
+env_var_errors << "GITHUB_TOKEN" if token.empty?
+env_var_errors << "COMMIT_SHA" if commit_sha.empty?
+
+raise "Missing required env vars: #{env_var_errors.join(', ')}" unless env_var_errors.empty?
+
+poster = GitHubReviewPoster.new(
+  owner:,
+  repo:,
+  pr_number: Integer(pr_number),
+  commit_sha:,
+  token:
+)
+
+if poster.post_batch_review(parsed.summary_body, parsed.inline_comments)
+  warn "[process_review] Posted batch review"
+  exit 0
+end
+
+exit 1 unless poster.post_summary_only(parsed.summary_body)
+
+warn "[process_review] Posted summary review; posting #{parsed.inline_comments.size} inline comment(s)"
+
+parsed.inline_comments.each_with_index do |c, i|
+  label = "Inline comment #{i + 1} failed"
+  warn "[process_review] Inline comment #{i + 1}: OK" if poster.post_single_comment(c, failure_label: label)
+end
+
+exit 0

--- a/.github/actions/agentic-pr-review/scripts/providers/cursor.sh
+++ b/.github/actions/agentic-pr-review/scripts/providers/cursor.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?}"
+: "${REVIEW_JSON_PATH:?}"
+: "${REVIEW_PROMPT_PATH:?}"
+
+export PATH="${HOME}/.local/bin:${PATH}"
+
+if ! command -v agent >/dev/null 2>&1; then
+  # Cursor documents this installer as the supported CLI install path. We intentionally
+  # take the latest version here because the CLI does not currently expose a documented
+  # version-pinned install flow that we can rely on in CI.
+  curl https://cursor.com/install -fsS | bash
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+if ! command -v agent >/dev/null 2>&1; then
+  echo "agent CLI not found after install" >&2
+  exit 1
+fi
+
+if [[ -z "${PROVIDER_API_KEY:-}" ]]; then
+  echo "PROVIDER_API_KEY is required for the cursor provider" >&2
+  exit 1
+fi
+
+export CURSOR_API_KEY="${PROVIDER_API_KEY}"
+
+if [[ ! -f "${REVIEW_PROMPT_PATH}" ]]; then
+  echo "Review prompt not found: ${REVIEW_PROMPT_PATH}" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTION_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CLI_CONFIG_TEMPLATE="${ACTION_ROOT}/config/cli-config.json"
+
+cd "${GITHUB_WORKSPACE}"
+
+mkdir -p .cursor
+cp "${CLI_CONFIG_TEMPLATE}" .cursor/cli-config.json
+
+PROMPT="$(cat "${REVIEW_PROMPT_PATH}")"
+if [[ -n "${REVIEW_ADDITIONAL_INSTRUCTIONS:-}" ]]; then
+  PROMPT+=$'\n\n## Additional instructions from the PR comment\n\n'"${REVIEW_ADDITIONAL_INSTRUCTIONS}"
+fi
+
+# --trust is required: headless agent refuses to run unless the workspace is trusted.
+# Read-only CLI permissions via .cursor/cli-config.json (copied from config/cli-config.json).
+agent --print --trust --output-format text "${PROMPT}" >"${REVIEW_JSON_PATH}"


### PR DESCRIPTION
## Summary
- Adds the `agentic-pr-review` composite action to `.github/actions/` so it can be referenced as a shared action across repositories.
- Includes the action definition, review prompt, CLI config, Ruby processing scripts with specs, and the Cursor provider shell script.

## Test plan
- [ ] Verify the action can be referenced from another repo via `powerhome/github-actions-workflows/.github/actions/agentic-pr-review@main`
- [ ] Confirm the composite action runs successfully in a test workflow

Made with [Cursor](https://cursor.com)