### PR TITLE
GLC-2102: Strip code fences from review JSON and parameterize model

### DIFF
--- a/agentic-pr-review/action.yml
+++ b/agentic-pr-review/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: Passed to rmacklin/fetch-through-merge-base as deepen_length
     required: false
     default: "30"
+  model:
+    description: Model to use for the review (passed to the provider CLI)
+    required: false
+    default: ""
   additional-prompt:
     description: Extra instructions appended to the review prompt (e.g. full text of an @nitro-pr-review PR comment)
     required: false
@@ -91,6 +95,7 @@ runs:
       env:
         PROVIDER: ${{ inputs.provider }}
         PROVIDER_API_KEY: ${{ inputs.provider-api-key }}
+        MODEL: ${{ inputs.model }}
         REVIEW_JSON_PATH: ${{ github.workspace }}/review-agent.json
         REVIEW_PROMPT_PATH: ${{ github.action_path }}/prompts/review.md
         REVIEW_ADDITIONAL_INSTRUCTIONS: ${{ inputs.additional-prompt }}

--- a/agentic-pr-review/scripts/agent_review_parser.rb
+++ b/agentic-pr-review/scripts/agent_review_parser.rb
@@ -12,7 +12,7 @@ class AgentReviewParser
   end
 
   def initialize(json_string)
-    @payload = JSON.parse(json_string)
+    @payload = JSON.parse(strip_code_fences(json_string))
     validate_root!
     @summary_body = build_summary_body
     @inline_comments = build_inline_comments
@@ -21,6 +21,12 @@ class AgentReviewParser
   attr_reader :summary_body, :inline_comments
 
 private
+
+  def strip_code_fences(raw)
+    stripped = raw.strip
+    stripped = stripped.sub(/\A```\w*\s*\n?/, "").sub(/\n?```\s*\z/, "") if stripped.start_with?("```")
+    stripped
+  end
 
   def validate_root!
     raise "Review JSON root must be a JSON object" unless @payload.is_a?(Hash)

--- a/agentic-pr-review/scripts/agent_review_parser_spec.rb
+++ b/agentic-pr-review/scripts/agent_review_parser_spec.rb
@@ -83,6 +83,32 @@ RSpec.describe AgentReviewParser do
     end
   end
 
+  describe "code fence stripping" do
+    it "parses JSON wrapped in ```json fences" do
+      raw = "```json\n#{{"summary" => "fenced"}.to_json}\n```"
+      parsed = described_class.new(raw)
+      expect(parsed.summary_body).to include("fenced")
+    end
+
+    it "parses JSON wrapped in bare ``` fences" do
+      raw = "```\n#{{"summary" => "bare"}.to_json}\n```"
+      parsed = described_class.new(raw)
+      expect(parsed.summary_body).to include("bare")
+    end
+
+    it "handles surrounding whitespace with fences" do
+      raw = "  \n```json\n#{{"summary" => "padded"}.to_json}\n```\n  "
+      parsed = described_class.new(raw)
+      expect(parsed.summary_body).to include("padded")
+    end
+
+    it "leaves plain JSON untouched" do
+      raw = {"summary" => "plain"}.to_json
+      parsed = described_class.new(raw)
+      expect(parsed.summary_body).to include("plain")
+    end
+  end
+
   describe "validation" do
     it "rejects a non-object JSON root" do
       expect do

--- a/agentic-pr-review/scripts/providers/cursor.sh
+++ b/agentic-pr-review/scripts/providers/cursor.sh
@@ -46,6 +46,11 @@ if [[ -n "${REVIEW_ADDITIONAL_INSTRUCTIONS:-}" ]]; then
   PROMPT+=$'\n\n## Additional instructions from the PR comment\n\n'"${REVIEW_ADDITIONAL_INSTRUCTIONS}"
 fi
 
+MODEL_ARGS=()
+if [[ -n "${MODEL:-}" ]]; then
+  MODEL_ARGS+=(--model "${MODEL}")
+fi
+
 # --trust is required: headless agent refuses to run unless the workspace is trusted.
 # Read-only CLI permissions via .cursor/cli-config.json (copied from config/cli-config.json).
-agent --print --trust --output-format text "${PROMPT}" >"${REVIEW_JSON_PATH}"
+agent --print --trust --output-format text "${MODEL_ARGS[@]}" "${PROMPT}" >"${REVIEW_JSON_PATH}"


### PR DESCRIPTION
## Summary
- Strip markdown code fences (e.g. `` ```json ... ``` ``) from the review agent's JSON output before parsing, fixing `JSON::ParserError` when the LLM wraps its response in fences.
- Add a new optional `model` input to the action, passed through to the provider CLI as `--model` so callers can override the default model.

## Test plan
- [x] All 12 `agent_review_parser_spec.rb` tests pass, including 4 new code-fence-stripping cases.
- [ ] Run the action on a test PR with `model` unset (should use CLI default).
- [ ] Run the action on a test PR with `model` set to a specific value (should pass `--model` to the agent CLI).

Made with [Cursor](https://cursor.com)