### PR TITLE
Rails is incompatible with Ruby 4.0 until v8

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0.2
+          ruby-version: 3.4.9
           bundler-cache: true
           working-directory: ${{ inputs.workdir }}
       - run: gem install license_finder


### PR DESCRIPTION
Most of the users of these workflows are held back to Ruby 3.x by Rails 7.x usage.

https://github.com/powerhome/nitro-intelligence.rb/actions/runs/24461442326/job/71476492256?pr=14