### PR TITLE
Robustly extract JSON from review output

### DIFF
--- a/agentic-pr-review/prompts/review.md
+++ b/agentic-pr-review/prompts/review.md
@@ -45,7 +45,12 @@ Do not emit a `medium` or `high` finding unless you can point to a plausible fai
 
 ## Output format
 
-Respond with **a single JSON object only**. No markdown code fences, no text before or after the JSON.
+Your **entire** response must be a single JSON object — nothing else. Specifically:
+
+- Do NOT include any text, explanation, or commentary before the opening `{`.
+- Do NOT include any text, explanation, or commentary after the closing `}`.
+- Do NOT wrap the JSON in markdown code fences (no `` ``` ``).
+- The very first character of your response must be `{` and the very last character must be `}`.
 
 Required shape (keys and types):
 
@@ -87,4 +92,4 @@ The summary should be brief and non-redundant.
 - Use the summary for overall outcome only: for example, whether the review found blocking issues, whether the diff looks sound overall, or the single highest-level concern.
 - If there are no inline comments, the summary may explain the key concern(s) directly.
 
-Output valid JSON only.
+Remember: output the raw JSON object only. No preamble, no postamble, no code fences. The first character must be `{`.

--- a/agentic-pr-review/scripts/agent_review_parser.rb
+++ b/agentic-pr-review/scripts/agent_review_parser.rb
@@ -12,7 +12,7 @@ class AgentReviewParser
   end
 
   def initialize(json_string)
-    @payload = JSON.parse(strip_code_fences(json_string))
+    @payload = JSON.parse(extract_json(json_string))
     validate_root!
     @summary_body = build_summary_body
     @inline_comments = build_inline_comments
@@ -22,10 +22,33 @@ class AgentReviewParser
 
 private
 
+  # Models sometimes emit prose or code fences around the JSON object.
+  # Strategy: strip code fences first, then fall back to extracting the
+  # substring between the first `{` and last `}` in the output.
+  def extract_json(raw)
+    stripped = strip_code_fences(raw)
+    return stripped if valid_json_object?(stripped)
+
+    first_brace = raw.index("{")
+    last_brace = raw.rindex("}")
+    if first_brace && last_brace && last_brace > first_brace
+      candidate = raw[first_brace..last_brace]
+      return candidate if valid_json_object?(candidate)
+    end
+
+    stripped
+  end
+
   def strip_code_fences(raw)
     stripped = raw.strip
     stripped = stripped.sub(/\A```\w*\s*\n?/, "").sub(/\n?```\s*\z/, "") if stripped.start_with?("```")
     stripped
+  end
+
+  def valid_json_object?(str)
+    JSON.parse(str).is_a?(Hash)
+  rescue JSON::ParserError
+    false
   end
 
   def validate_root!

--- a/agentic-pr-review/scripts/agent_review_parser_spec.rb
+++ b/agentic-pr-review/scripts/agent_review_parser_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe AgentReviewParser do
     end
   end
 
-  describe "code fence stripping" do
+  describe "JSON extraction" do
     it "parses JSON wrapped in ```json fences" do
       raw = "```json\n#{{"summary" => "fenced"}.to_json}\n```"
       parsed = described_class.new(raw)
@@ -106,6 +106,30 @@ RSpec.describe AgentReviewParser do
       raw = {"summary" => "plain"}.to_json
       parsed = described_class.new(raw)
       expect(parsed.summary_body).to include("plain")
+    end
+
+    it "extracts JSON when the model emits text before the object" do
+      raw = "Here is my review:\n#{{"summary" => "prefixed"}.to_json}"
+      parsed = described_class.new(raw)
+      expect(parsed.summary_body).to include("prefixed")
+    end
+
+    it "extracts JSON when the model emits text after the object" do
+      raw = "#{{"summary" => "suffixed"}.to_json}\nI hope this helps!"
+      parsed = described_class.new(raw)
+      expect(parsed.summary_body).to include("suffixed")
+    end
+
+    it "extracts JSON when the model emits text before and after" do
+      raw = "Sure, here you go:\n#{{"summary" => "wrapped", "comments" => []}.to_json}\nLet me know if you need more."
+      parsed = described_class.new(raw)
+      expect(parsed.summary_body).to include("wrapped")
+    end
+
+    it "extracts JSON when the model wraps with prose and code fences" do
+      raw = "Here is the review:\n```json\n#{{"summary" => "both"}.to_json}\n```\nDone!"
+      parsed = described_class.new(raw)
+      expect(parsed.summary_body).to include("both")
     end
   end
 


### PR DESCRIPTION
## Summary

- **Parser**: adds `extract_json` method that falls back to extracting the substring between the first `{` and last `}` when the model emits prose or code fences around the JSON object. The existing `strip_code_fences` path is tried first, so clean output is unaffected.
- **Prompt**: strengthens the output format instructions — explicitly states the first character must be `{`, the last must be `}`, and lists specific "Do NOT" bullets for common failure modes.
- **Specs**: adds 4 new test cases covering text-before, text-after, text-on-both-sides, and prose-plus-code-fences scenarios. All 16 specs pass.

## Test plan

- [x] `ruby agentic-pr-review/scripts/agent_review_parser_spec.rb` — 16 examples, 0 failures

Made with [Cursor](https://cursor.com)