### PR TITLE
Require inline review comments to anchor to changed lines

### DIFF
--- a/agentic-pr-review/prompts/review.md
+++ b/agentic-pr-review/prompts/review.md
@@ -66,6 +66,17 @@ Example object (structure only; your output must be raw JSON, not wrapped in bac
 
     { "summary": "…", "comments": [ { "path": "src/a.rb", "line": 10, "body": "…", "severity": "high" } ] }
 
+## Anchoring comments to the diff
+
+Every inline comment's `path` and `line` must point to a line that this PR actually changed. GitHub rejects review comments on files or lines that are not part of the diff (HTTP 422), which drops the entire review.
+
+If the observation is about a file the PR did not modify — for example, dead code, a template, or a caller that becomes stale as a consequence of this PR's changes — do **not** put that file's path in `path`. Instead:
+
+- Anchor the comment to the changed line in the PR that prompted the observation, and reference the unmodified file by name inside the comment `body`. For example: "This caller change leaves `app/views/foo/_bar.html.erb` with a now-unused `.transcription_text` div…"
+- Or, if no changed line is a natural anchor, fold the observation into the top-level `summary` instead and omit the inline comment.
+
+Before emitting each inline comment, verify its `path` appears in `pr.diff` and its `line` falls on a line the diff added or modified on the PR head.
+
 ## Comment style
 
 For each inline comment:


### PR DESCRIPTION
## Summary
- A recent run on `powerhome/nitro-web#58167` failed with a GitHub 422 because the reviewer placed an inline comment on `components/nitro_theme/app/views/shared/_call_recording_player_modal.html.erb` — a file that exists in the repo but is not part of the PR diff. GitHub rejects review comments on lines not in the diff, which drops the entire review.
- Adds an "Anchoring comments to the diff" section to the review prompt instructing the reviewer to anchor inline comments to a changed line, reference unmodified files in the comment body when needed, or move the observation to the top-level summary if no changed line is a natural anchor.

## Test plan
- [ ] Next agentic review run posts successfully without 422s when the model wants to comment on collateral/unmodified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)