### PR TITLE
[GOG-1783] Authenticate yarn install against npm.powerapp.cloud

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -1,5 +1,8 @@
 on:
   workflow_call:
+    secrets:
+      npm_token:
+        required: false
     inputs:
       workdir:
         required: false
@@ -14,6 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Enable npm.powerapp.cloud auth
+        shell: bash
+        env:
+          NPM_REGISTRY_PASSWORD: ${{ secrets.npm_token }}
+        run: |
+          if [ -z "$NPM_REGISTRY_PASSWORD" ]; then
+            exit 0
+          fi
+
+          auth="$(printf 'gh-actions:%s' "$NPM_REGISTRY_PASSWORD" | base64 | tr -d '\n')"
+          echo "::add-mask::$auth"
+          {
+            echo "registry=https://npm.powerapp.cloud"
+            echo "//npm.powerapp.cloud/:_auth=${auth}"
+            echo "//npm.powerapp.cloud/:always-auth=true"
+          } >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/yarn-package.yml
+++ b/.github/workflows/yarn-package.yml
@@ -36,8 +36,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          registry-url: https://npm.powerapp.cloud
+          always-auth: true
       - run: yarn install --frozen-lockfile
         working-directory: ${{ inputs.workdir }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
       - run: yarn lint
         working-directory: ${{ inputs.workdir }}
       - run: yarn build

--- a/.github/workflows/yarn-package.yml
+++ b/.github/workflows/yarn-package.yml
@@ -36,12 +36,20 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-          registry-url: https://npm.powerapp.cloud
-          always-auth: true
+      - name: Enable npm.powerapp.cloud auth
+        shell: bash
+        env:
+          NPM_REGISTRY_PASSWORD: ${{ secrets.npm_token }}
+        run: |
+          auth="$(printf 'gh-actions:%s' "$NPM_REGISTRY_PASSWORD" | base64 | tr -d '\n')"
+          echo "::add-mask::$auth"
+          {
+            echo "registry=https://npm.powerapp.cloud"
+            echo "//npm.powerapp.cloud/:_auth=${auth}"
+            echo "//npm.powerapp.cloud/:always-auth=true"
+          } >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
       - run: yarn install --frozen-lockfile
         working-directory: ${{ inputs.workdir }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
       - run: yarn lint
         working-directory: ${{ inputs.workdir }}
       - run: yarn build
@@ -54,6 +62,8 @@ jobs:
     with:
       workdir: "${{ inputs.workdir }}"
       decisions: "${{ inputs.license-decisions }}"
+    secrets:
+      npm_token: ${{ secrets.npm_token }}
 
   release:
     needs: [build, license-compliance]


### PR DESCRIPTION
## Summary
- The build job in `yarn-package.yml` runs on GitHub-hosted runners whose egress IPs aren't in the HAProxy LAN allowlist (`10/8`, `192.168/16`, `172.16/12`) that fronts `npm.powerapp.cloud`. Unauthenticated tarball fetches receive `401 + WWW-Authenticate: Basic realm="npm-registry"`.
- Until now this was latent: existing consumer `yarn.lock` files had every entry resolved at `registry.yarnpkg.com`, so the build job never actually hit the internal registry. Renovate (configured via `powerhome/renovate-config`'s `use-internal-registry.json`) writes new lockfile entries with `resolved: https://npm.powerapp.cloud/...`, which forces yarn install to authenticate.
- The `npm_token` secret was already declared as required on this reusable workflow but only consumed by the `release` job. This wires it into the build job too via `setup-node`'s `registry-url` / `always-auth` and `NODE_AUTH_TOKEN` on `yarn install`.

Trigger / first observed failure: [powerhome/compass#117 "Update dependency eslint to v10"](https://github.com/powerhome/compass/pull/117) — first PR to introduce a new dep through this workflow after Renovate's internal-registry config landed.

## Test plan
- [ ] After merge, re-run CI on [powerhome/compass#117](https://github.com/powerhome/compass/pull/117); `yarn install --frozen-lockfile` should succeed against the Renovate-generated `resolved: https://npm.powerapp.cloud/...` URLs.
- [ ] Confirm no regression on other consumers of `yarn-package.yml` (existing repos whose lockfiles still point at `registry.yarnpkg.com` should continue to work; `setup-node` writing an authenticated `.npmrc` doesn't affect requests to other hosts).
- [ ] Sanity check the `release` job still works on the next tag push — it sets its own `registry-url: https://registry.npmjs.org` for `yarn publish`, which is unrelated to the build-job change here.