### PR TITLE
[HFH] Prevent acceptance criteria comment recursion

### DIFF
--- a/agentic-acceptance-criteria/README.md
+++ b/agentic-acceptance-criteria/README.md
@@ -34,7 +34,7 @@ The raw `acceptance-criteria-agent.json` file is uploaded as an artifact for deb
 
 ## Secrets and permissions
 
-The calling workflow needs `contents: read` and `pull-requests: write`. The GitHub App installation must be able to clone the target repository and create or edit its PR comments.
+The calling workflow needs `contents: read` and `pull-requests: write`. The GitHub App installation token is used to read PR metadata and clone the target repository. PR comments use the calling workflow's `GITHUB_TOKEN` so action-authored comments do not trigger recursive `issue_comment` workflow runs.
 
 The action can reuse the same secrets as `agentic-pr-review`:
 
@@ -76,7 +76,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   acceptance-criteria:

--- a/agentic-acceptance-criteria/action.yml
+++ b/agentic-acceptance-criteria/action.yml
@@ -44,7 +44,8 @@ runs:
     - name: Post in-progress status comment
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
-        github-token: ${{ steps.app_token.outputs.token }}
+        # GITHUB_TOKEN-authored comments do not trigger recursive issue_comment runs.
+        github-token: ${{ github.token }}
         pr-number: ${{ inputs.pull-request-number }}
         comment-tag: agentic-acceptance-criteria-status
         mode: delete-on-completion
@@ -146,7 +147,7 @@ runs:
       id: acceptance_criteria_comment
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
-        github-token: ${{ steps.app_token.outputs.token }}
+        github-token: ${{ github.token }}
         pr-number: ${{ inputs.pull-request-number }}
         comment-tag: agentic-acceptance-criteria
         mode: upsert
@@ -156,7 +157,7 @@ runs:
       continue-on-error: true
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
-        github-token: ${{ steps.app_token.outputs.token }}
+        github-token: ${{ github.token }}
         pr-number: ${{ inputs.pull-request-number }}
         comment-tag: agentic-acceptance-criteria-failure
         mode: delete
@@ -166,7 +167,7 @@ runs:
       if: failure() && steps.acceptance_criteria_comment.outcome != 'success'
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
-        github-token: ${{ steps.app_token.outputs.token }}
+        github-token: ${{ github.token }}
         pr-number: ${{ inputs.pull-request-number }}
         comment-tag: agentic-acceptance-criteria-failure
         mode: upsert


### PR DESCRIPTION
Post progress, result, cleanup, and failure comments with the calling workflow's GITHUB_TOKEN. GitHub suppresses workflow runs caused by that token, so action-authored comments no longer feed back into the issue_comment trigger.

Keep the GitHub App token for PR metadata and checkout, preserve the existing Cursor credentials, and document non-canceling concurrency for consumers.