### PR TITLE
[HFH-4819] Tweak Agentic Acceptance Criteria output

### DIFF
--- a/agentic-acceptance-criteria/README.md
+++ b/agentic-acceptance-criteria/README.md
@@ -4,9 +4,9 @@ Generates a structured manual QA plan from a pull request's **merge-base diff** 
 
 The generated plan is written for non-technical testers and contains:
 
-- Permissions and roles to test.
-- Feature-oriented test scenarios with observable outcomes.
-- Targeted regression testing.
+- Permissions and roles to test, including exact permission Subject/Action pairs.
+- Test-path-oriented scenarios with landing-page relative URLs and per-case permissions.
+- Targeted regression testing that references applicable functional case identifiers.
 
 ## What it does
 
@@ -122,7 +122,7 @@ This workflow does not listen for PR opening, ready-for-review, or synchronizati
 
 ## Generation context
 
-The provider receives `pr.diff`, read-only access to repository files for context, and `additional-prompt` when supplied. The PR title is used only by the deterministic formatter's heading, and the PR title and description are not included in the provider prompt.
+The provider receives `pr.diff`, read-only access to repository files for context, and `additional-prompt` when supplied. It groups functional cases by similar tester paths before using product domain as a secondary classification. The PR title is used only by the deterministic formatter's heading, and the PR title and description are not included in the provider prompt.
 
 ## Cursor permissions
 

--- a/agentic-acceptance-criteria/action.yml
+++ b/agentic-acceptance-criteria/action.yml
@@ -139,7 +139,6 @@ runs:
       env:
         ACCEPTANCE_CRITERIA_JSON_PATH: ${{ github.workspace }}/acceptance-criteria-agent.json
         ACCEPTANCE_CRITERIA_COMMENT_PATH: ${{ github.workspace }}/acceptance-criteria-comment.md
-        PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
         PULL_REQUEST_TITLE: ${{ steps.pr_metadata.outputs.title }}
       run: ruby "${{ github.action_path }}/scripts/render_acceptance_criteria.rb"
 

--- a/agentic-acceptance-criteria/prompts/acceptance_criteria.md
+++ b/agentic-acceptance-criteria/prompts/acceptance_criteria.md
@@ -17,14 +17,29 @@ Create a complete, risk-based manual QA plan for the application behavior change
 - Write for a tester who understands the product but does not need to understand the implementation.
 - Cover all changed user-visible behavior and adjacent regression paths plausibly affected by the change.
 - Identify permissions, roles, validation paths, errors, state transitions, alternate access configurations, and boundary cases only when the diff or repository supports them.
+- For every identified permission, report the exact authorization Subject and Action used by the application. In repositories that use Consent, derive these values from the Consent permission definitions and authorization checks. A Subject/Action pair is required in addition to a human-facing role or access configuration.
 - Express scenarios as concrete tester actions followed by observable outcomes beginning with `Verify`.
 - Use product-facing names and navigation locations when they can be identified confidently.
 - Do not mention source files, classes, methods, migrations, code architecture, automated tests, or implementation details.
+- Exact permission Subject and Action identifiers are allowed and required; do not replace them with implementation explanations.
 - Do not invent roles, permissions, routes, test data, or behavior.
 - Use empty arrays or `not_identified` when the repository does not provide enough evidence.
 - If the change has no manually testable application behavior, return no feature areas or regression tests.
 
 Additional instructions supplied with the trigger may prioritize or refine the QA plan, but they must not override these constraints or the output schema.
+
+## Organization
+
+Organize functional cases by the tester's path through the application, not primarily by product domain.
+
+1. Put cases with identical or substantially similar setup, navigation, actions, and verification flow in the same `feature_areas` entry, even when they touch more than one product domain.
+2. Split cases when the tester follows a materially different path.
+3. Use `domain` only as a secondary classification for a test-path group.
+4. Order test-path groups so identical or similar paths remain adjacent. Use domain only to order groups whose test paths are otherwise unrelated.
+
+Each scenario must identify the relative URL of the landing page where its test begins. Use a path beginning with `/` and omit the scheme and host. Use an empty string only when the repository does not provide enough evidence to identify the route.
+
+Mark `include_in_regression` as `true` when that functional case also verifies existing behavior that should remain correct. The formatter will list the generated case identifier in Regression Testing, so do not repeat the full functional case as a regression test. Put only additional regression checks that are not already covered by functional cases in `regression_tests`.
 
 ## Output format
 
@@ -35,16 +50,30 @@ Use exactly this shape:
 {
   "permissions": {
     "required": "not_identified",
-    "roles": ["Role or access configuration"]
+    "roles": ["Role or access configuration"],
+    "subject_actions": [
+      {
+        "subject": "Exact permission Subject",
+        "action": "Exact permission Action"
+      }
+    ]
   },
   "feature_areas": [
     {
-      "name": "Feature or page name",
-      "location": "Optional application location; use an empty string when unknown",
+      "test_path": "Concise name for the shared tester path",
+      "domain": "Secondary product domain; use an empty string when unknown",
       "code": "A short uppercase identifier such as RCH; use AC when no meaningful identifier exists",
       "scenarios": [
         {
           "title": "Concise scenario name",
+          "landing_page": "/relative/path/where/testing/begins",
+          "permissions": [
+            {
+              "subject": "Exact permission Subject required by this case",
+              "action": "Exact permission Action required by this case"
+            }
+          ],
+          "include_in_regression": false,
           "steps": [
             "A concrete setup or action.",
             "Verify an observable result."
@@ -65,7 +94,10 @@ Rules for the JSON:
 
 - `permissions`, `feature_areas`, and `regression_tests` are required.
 - `permissions.required` must be exactly `yes`, `no`, or `not_identified`.
-- Every role, name, location, code, title, step, regression text, and detail must be a string.
+- `permissions.roles` and `permissions.subject_actions` are required arrays.
+- Every `test_path`, `domain`, `code`, `title`, `landing_page`, step, role, permission Subject, permission Action, regression text, and detail must be a string.
+- Every scenario must include a `permissions` array and a boolean `include_in_regression`.
+- Include every Subject/Action pair used by the plan in `permissions.subject_actions`, and repeat the applicable pair or pairs in each scenario's `permissions`.
 - Every scenario must contain at least one action and one observable verification.
 - Keep steps concise and independently executable.
 - Do not number scenarios; the formatter assigns stable identifiers.

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter.rb
@@ -4,6 +4,7 @@ class AcceptanceCriteriaFormatter
   NO_MANUAL_QA_MESSAGE = "No manual application QA was identified for this change."
   NO_REGRESSION_MESSAGE = "No targeted regression testing was identified for this change."
   NO_ROLES_MESSAGE = "Not identified from this change."
+  NO_SUBJECT_ACTIONS_MESSAGE = "Not identified from this change."
 
   PERMISSION_LABELS = {
     "yes" => "Yes",
@@ -11,10 +12,10 @@ class AcceptanceCriteriaFormatter
     "not_identified" => "Not identified",
   }.freeze
 
-  def initialize(parsed:, pull_request_number:, pull_request_title:)
+  def initialize(parsed:, pull_request_title:)
     @parsed = parsed
-    @pull_request_number = pull_request_number
     @pull_request_title = normalize_text(pull_request_title)
+    @case_identifiers = build_case_identifiers
   end
 
   def render
@@ -34,8 +35,8 @@ class AcceptanceCriteriaFormatter
 private
 
   def heading
-    title_suffix = @pull_request_title.empty? ? "" : " — #{@pull_request_title}"
-    "## ✅ Test Plan: PR ##{@pull_request_number}#{title_suffix}"
+    title_suffix = @pull_request_title.empty? ? "" : ": #{@pull_request_title}"
+    "## ✅ Test Plan#{title_suffix}"
   end
 
   def permissions_section
@@ -54,6 +55,15 @@ private
       roles.each { |role| lines << "  - #{role}" }
     end
 
+    subject_actions = @parsed.permissions.fetch("subject_actions")
+    if subject_actions.empty?
+      subject_actions_message = @parsed.permissions.fetch("required") == "no" ? "No special permission required." : NO_SUBJECT_ACTIONS_MESSAGE
+      lines << "- **Permission Subjects / Actions:** #{subject_actions_message}"
+    else
+      lines << "- **Permission Subjects / Actions:**"
+      subject_actions.each { |permission| lines << permission_line(permission, "  ") }
+    end
+
     lines.join("\n")
   end
 
@@ -65,7 +75,6 @@ private
       return lines.join("\n")
     end
 
-    code_counts = Hash.new(0)
     @parsed.feature_areas.each_with_index do |area, area_index|
       lines << "" unless area_index.zero?
       lines << feature_heading(area)
@@ -73,9 +82,10 @@ private
 
       area.fetch("scenarios").each_with_index do |scenario, scenario_index|
         lines << "" unless scenario_index.zero?
-        code = area.fetch("code")
-        code_counts[code] += 1
-        lines << "- **#{code}-#{code_counts[code]} — #{scenario.fetch("title")}**"
+        identifier = @case_identifiers.fetch(scenario.object_id)
+        lines << "- **#{identifier} — #{scenario.fetch("title")}**"
+        lines << "  - **Landing Page:** #{format_landing_page(scenario.fetch("landing_page"))}"
+        lines.concat(scenario_permission_lines(scenario))
         scenario.fetch("steps").each { |step| lines << "  - #{step}" }
       end
     end
@@ -84,17 +94,22 @@ private
   end
 
   def feature_heading(area)
-    location = area.fetch("location").delete("`")
-    suffix = location.empty? ? "" : " — `#{location}`"
-    "#### #{area.fetch("name")}#{suffix}"
+    domain = area.fetch("domain")
+    suffix = domain.empty? ? "" : " — #{domain}"
+    "#### #{area.fetch("test_path")}#{suffix}"
   end
 
   def regression_section
     lines = ["### Regression Testing", ""]
+    applicable_cases = regression_case_identifiers
 
-    if @parsed.regression_tests.empty?
+    if applicable_cases.empty? && @parsed.regression_tests.empty?
       lines << "- #{NO_REGRESSION_MESSAGE}"
       return lines.join("\n")
+    end
+
+    unless applicable_cases.empty?
+      lines << "- **Applicable Functional Cases:** #{applicable_cases.join(", ")}"
     end
 
     @parsed.regression_tests.each do |test|
@@ -103,6 +118,50 @@ private
     end
 
     lines.join("\n")
+  end
+
+  def build_case_identifiers
+    code_counts = Hash.new(0)
+
+    @parsed.feature_areas.each_with_object({}) do |area, identifiers|
+      area.fetch("scenarios").each do |scenario|
+        code = area.fetch("code")
+        code_counts[code] += 1
+        identifiers[scenario.object_id] = "#{code}-#{code_counts[code]}"
+      end
+    end
+  end
+
+  def regression_case_identifiers
+    @parsed.feature_areas.flat_map do |area|
+      area.fetch("scenarios").filter_map do |scenario|
+        @case_identifiers.fetch(scenario.object_id) if scenario.fetch("include_in_regression")
+      end
+    end
+  end
+
+  def scenario_permission_lines(scenario)
+    permissions = scenario.fetch("permissions")
+    if permissions.empty?
+      message = @parsed.permissions.fetch("required") == "no" ? "No special permission required." : "Not identified for this case."
+      return ["  - **Permissions:** #{message}"]
+    end
+
+    [
+      "  - **Permissions:**",
+      *permissions.map { |permission| permission_line(permission, "    ") },
+    ]
+  end
+
+  def permission_line(permission, indentation)
+    subject = permission.fetch("subject").delete("`")
+    action = permission.fetch("action").delete("`")
+    "#{indentation}- **Subject:** `#{subject}`; **Action:** `#{action}`"
+  end
+
+  def format_landing_page(value)
+    landing_page = value.delete("`")
+    landing_page.empty? ? "Not identified from this change." : "`#{landing_page}`"
   end
 
   def normalize_text(value)

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter_spec.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe AcceptanceCriteriaFormatter do
   def render(payload, title: "Reminder Calls migration")
     described_class.new(
       parsed: parse(payload),
-      pull_request_number: "42",
       pull_request_title: title
     ).render
   end
@@ -30,15 +29,24 @@ RSpec.describe AcceptanceCriteriaFormatter do
       "permissions" => {
         "required" => "yes",
         "roles" => ["User with Reminder Call History read access"],
+        "subject_actions" => [
+          { "subject" => "ReminderCall", "action" => "read" },
+          { "subject" => "Project", "action" => "read" },
+        ],
       },
       "feature_areas" => [
         {
-          "name" => "Reminder Call History",
-          "location" => "BASE/contact_center/reminder_calls",
+          "test_path" => "View and filter reminder call history",
+          "domain" => "Contact Center",
           "code" => "RCH",
           "scenarios" => [
             {
               "title" => "Page load/default results",
+              "landing_page" => "/contact_center/reminder_calls",
+              "permissions" => [
+                { "subject" => "ReminderCall", "action" => "read" },
+              ],
+              "include_in_regression" => true,
               "steps" => [
                 "Open Reminder Call History.",
                 "Verify the default results display.",
@@ -46,6 +54,12 @@ RSpec.describe AcceptanceCriteriaFormatter do
             },
             {
               "title" => "Project filter",
+              "landing_page" => "/contact_center/reminder_calls",
+              "permissions" => [
+                { "subject" => "ReminderCall", "action" => "read" },
+                { "subject" => "Project", "action" => "read" },
+              ],
+              "include_in_regression" => false,
               "steps" => [
                 "Filter by a project number prefix.",
                 "Verify unrelated projects are removed.",
@@ -65,7 +79,7 @@ RSpec.describe AcceptanceCriteriaFormatter do
 
   it "renders the agreed QA hierarchy and deterministic scenario identifiers" do
     expect(render(payload)).to eq(<<~MARKDOWN)
-      ## ✅ Test Plan: PR #42 — Reminder Calls migration
+      ## ✅ Test Plan: Reminder Calls migration
 
       ---
 
@@ -74,18 +88,28 @@ RSpec.describe AcceptanceCriteriaFormatter do
       - **Required Permissions:** Yes
       - **Roles to Test:**
         - User with Reminder Call History read access
+      - **Permission Subjects / Actions:**
+        - **Subject:** `ReminderCall`; **Action:** `read`
+        - **Subject:** `Project`; **Action:** `read`
 
       ---
 
       ### Functional / Features to Test
 
-      #### Reminder Call History — `BASE/contact_center/reminder_calls`
+      #### View and filter reminder call history — Contact Center
 
       - **RCH-1 — Page load/default results**
+        - **Landing Page:** `/contact_center/reminder_calls`
+        - **Permissions:**
+          - **Subject:** `ReminderCall`; **Action:** `read`
         - Open Reminder Call History.
         - Verify the default results display.
 
       - **RCH-2 — Project filter**
+        - **Landing Page:** `/contact_center/reminder_calls`
+        - **Permissions:**
+          - **Subject:** `ReminderCall`; **Action:** `read`
+          - **Subject:** `Project`; **Action:** `read`
         - Filter by a project number prefix.
         - Verify unrelated projects are removed.
 
@@ -93,6 +117,7 @@ RSpec.describe AcceptanceCriteriaFormatter do
 
       ### Regression Testing
 
+      - **Applicable Functional Cases:** RCH-1
       - Verify existing links still work.
         - Project links.
         - Recording links.
@@ -101,12 +126,15 @@ RSpec.describe AcceptanceCriteriaFormatter do
 
   it "continues numbering when multiple feature areas use the same code" do
     second_area = {
-      "name" => "Reminder Call Dashboard",
-      "location" => "",
+      "test_path" => "Open the reminder call dashboard",
+      "domain" => "Contact Center",
       "code" => "RCH",
       "scenarios" => [
         {
           "title" => "Dashboard navigation",
+          "landing_page" => "/contact_center",
+          "permissions" => [],
+          "include_in_regression" => false,
           "steps" => ["Verify the dashboard opens."],
         },
       ],
@@ -121,6 +149,7 @@ RSpec.describe AcceptanceCriteriaFormatter do
       "permissions" => {
         "required" => "not_identified",
         "roles" => [],
+        "subject_actions" => [],
       },
       "feature_areas" => [],
       "regression_tests" => [],
@@ -128,9 +157,10 @@ RSpec.describe AcceptanceCriteriaFormatter do
 
     output = render(empty_payload, title: "")
 
-    expect(output).to include("## ✅ Test Plan: PR #42")
+    expect(output).to include("## ✅ Test Plan")
     expect(output).to include("**Required Permissions:** Not identified")
     expect(output).to include("**Roles to Test:** Not identified from this change.")
+    expect(output).to include("**Permission Subjects / Actions:** Not identified from this change.")
     expect(output).to include("- No manual application QA was identified for this change.")
     expect(output).to include("- No targeted regression testing was identified for this change.")
   end
@@ -140,6 +170,7 @@ RSpec.describe AcceptanceCriteriaFormatter do
       "permissions" => {
         "required" => "no",
         "roles" => [],
+        "subject_actions" => [],
       },
       "feature_areas" => [],
       "regression_tests" => [],
@@ -148,14 +179,31 @@ RSpec.describe AcceptanceCriteriaFormatter do
     expect(render(no_permissions_payload)).to include(
       "**Roles to Test:** No special role required."
     )
+    expect(render(no_permissions_payload)).to include(
+      "**Permission Subjects / Actions:** No special permission required."
+    )
   end
 
-  it "normalizes the PR title and removes backticks from locations" do
-    payload["feature_areas"].first["location"] = "BASE/`unsafe`"
+  it "normalizes the PR title without linking the PR and removes backticks from identifiers" do
+    payload["feature_areas"].first["scenarios"].first["landing_page"] = "/`unsafe`"
+    payload["permissions"]["subject_actions"].first["subject"] = "`ReminderCall`"
 
     output = render(payload, title: "  Search\nmigration  ")
 
-    expect(output).to start_with("## ✅ Test Plan: PR #42 — Search migration")
-    expect(output).to include("`BASE/unsafe`")
+    expect(output).to start_with("## ✅ Test Plan: Search migration")
+    expect(output).not_to include("PR #")
+    expect(output).to include("`/unsafe`")
+    expect(output).to include("**Subject:** `ReminderCall`")
+  end
+
+  it "lists only functional identifiers when regressions are fully covered by functional cases" do
+    payload["feature_areas"].first["scenarios"].last["include_in_regression"] = true
+    payload["regression_tests"] = []
+
+    regression_section = render(payload).split("### Regression Testing", 2).last
+
+    expect(regression_section).to include("**Applicable Functional Cases:** RCH-1, RCH-2")
+    expect(regression_section).not_to include("Page load/default results")
+    expect(regression_section).not_to include("Project filter")
   end
 end

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_parser.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_parser.rb
@@ -10,7 +10,7 @@ class AcceptanceCriteriaParser
   attr_reader :permissions, :feature_areas, :regression_tests
 
   def self.parse_file(path)
-    new(File.read(path))
+    new(File.read(path, encoding: Encoding::UTF_8))
   end
 
   def initialize(json_string)

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_parser.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_parser.rb
@@ -55,6 +55,9 @@ private
     unless @payload.dig("permissions", "roles").is_a?(Array)
       raise 'Acceptance-criteria permissions must include a "roles" array'
     end
+    unless @payload.dig("permissions", "subject_actions").is_a?(Array)
+      raise 'Acceptance-criteria permissions must include a "subject_actions" array'
+    end
     raise 'Acceptance-criteria JSON must include a "feature_areas" array' unless @payload["feature_areas"].is_a?(Array)
     unless @payload["regression_tests"].is_a?(Array)
       raise 'Acceptance-criteria JSON must include a "regression_tests" array'
@@ -69,6 +72,7 @@ private
     {
       "required" => required,
       "roles" => unique_strings(raw.fetch("roles")),
+      "subject_actions" => permission_pairs(raw.fetch("subject_actions")),
     }
   end
 
@@ -81,13 +85,13 @@ private
   def build_feature_area(entry)
     return unless entry.is_a?(Hash)
 
-    name = normalize_text(entry["name"])
+    test_path = normalize_text(entry["test_path"])
     scenarios = Array(entry["scenarios"]).filter_map { |scenario| build_scenario(scenario) }
-    return if name.empty? || scenarios.empty?
+    return if test_path.empty? || scenarios.empty?
 
     {
-      "name" => name,
-      "location" => normalize_text(entry["location"]),
+      "test_path" => test_path,
+      "domain" => normalize_text(entry["domain"]),
       "code" => normalize_feature_code(entry["code"]),
       "scenarios" => scenarios,
     }
@@ -102,6 +106,9 @@ private
 
     {
       "title" => title,
+      "landing_page" => normalize_text(entry["landing_page"]),
+      "permissions" => permission_pairs(Array(entry["permissions"])),
+      "include_in_regression" => entry["include_in_regression"] == true,
       "steps" => steps,
     }
   end
@@ -126,6 +133,25 @@ private
   def normalize_feature_code(value)
     code = normalize_text(value).upcase
     FEATURE_CODE_PATTERN.match?(code) ? code : DEFAULT_FEATURE_CODE
+  end
+
+  def permission_pairs(values)
+    seen = {}
+
+    values.filter_map do |value|
+      next unless value.is_a?(Hash)
+
+      subject = normalize_text(value["subject"])
+      action = normalize_text(value["action"])
+      key = [subject, action]
+      next if subject.empty? || action.empty? || seen[key]
+
+      seen[key] = true
+      {
+        "subject" => subject,
+        "action" => action,
+      }
+    end
   end
 
   def unique_strings(values)

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_parser_spec.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_parser_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe AcceptanceCriteriaParser do
       "permissions" => {
         "required" => "yes",
         "roles" => ["Dispatcher"],
+        "subject_actions" => [
+          { "subject" => "ReminderCall", "action" => "read" },
+        ],
       },
       "feature_areas" => [],
       "regression_tests" => [],
@@ -25,11 +28,17 @@ RSpec.describe AcceptanceCriteriaParser do
   end
 
   describe "#permissions" do
-    it "normalizes permission values and deduplicates roles" do
+    it "normalizes permission values and deduplicates roles and Subject/Action pairs" do
       raw = payload(
         "permissions" => {
           "required" => "Not Identified",
           "roles" => ["  Dispatcher\nwith access  ", "Dispatcher with access", "", nil],
+          "subject_actions" => [
+            { "subject" => " ReminderCall ", "action" => " read " },
+            { "subject" => "ReminderCall", "action" => "read" },
+            { "subject" => "", "action" => "update" },
+            "invalid",
+          ],
         }
       )
 
@@ -37,12 +46,21 @@ RSpec.describe AcceptanceCriteriaParser do
 
       expect(parsed.permissions).to eq(
         "required" => "not_identified",
-        "roles" => ["Dispatcher with access"]
+        "roles" => ["Dispatcher with access"],
+        "subject_actions" => [
+          { "subject" => "ReminderCall", "action" => "read" },
+        ]
       )
     end
 
     it "uses not_identified for an unsupported permission value" do
-      raw = payload("permissions" => { "required" => "maybe", "roles" => [] })
+      raw = payload(
+        "permissions" => {
+          "required" => "maybe",
+          "roles" => [],
+          "subject_actions" => [],
+        }
+      )
       expect(described_class.new(raw.to_json).permissions["required"]).to eq("not_identified")
     end
   end
@@ -52,12 +70,18 @@ RSpec.describe AcceptanceCriteriaParser do
       raw = payload(
         "feature_areas" => [
           {
-            "name" => " Reminder Call History ",
-            "location" => " BASE/contact_center/reminder_calls ",
+            "test_path" => " View and filter reminder call history ",
+            "domain" => " Contact Center ",
             "code" => "rch",
             "scenarios" => [
               {
                 "title" => " Page load ",
+                "landing_page" => " /contact_center/reminder_calls ",
+                "permissions" => [
+                  { "subject" => " ReminderCall ", "action" => " read " },
+                  { "subject" => "ReminderCall", "action" => "read" },
+                ],
+                "include_in_regression" => true,
                 "steps" => [
                   "Open the page.",
                   " Verify default results. ",
@@ -69,7 +93,8 @@ RSpec.describe AcceptanceCriteriaParser do
             ],
           },
           {
-            "name" => "Empty area",
+            "test_path" => "Empty area",
+            "domain" => "",
             "code" => "EA",
             "scenarios" => [],
           },
@@ -81,12 +106,17 @@ RSpec.describe AcceptanceCriteriaParser do
       expect(parsed.feature_areas).to eq(
         [
           {
-            "name" => "Reminder Call History",
-            "location" => "BASE/contact_center/reminder_calls",
+            "test_path" => "View and filter reminder call history",
+            "domain" => "Contact Center",
             "code" => "RCH",
             "scenarios" => [
               {
                 "title" => "Page load",
+                "landing_page" => "/contact_center/reminder_calls",
+                "permissions" => [
+                  { "subject" => "ReminderCall", "action" => "read" },
+                ],
+                "include_in_regression" => true,
                 "steps" => ["Open the page.", "Verify default results."],
               },
             ],
@@ -99,10 +129,18 @@ RSpec.describe AcceptanceCriteriaParser do
       raw = payload(
         "feature_areas" => [
           {
-            "name" => "Search",
-            "location" => "",
+            "test_path" => "Search",
+            "domain" => "",
             "code" => "too-long-code",
-            "scenarios" => [{ "title" => "Filter", "steps" => ["Verify filtering."] }],
+            "scenarios" => [
+              {
+                "title" => "Filter",
+                "landing_page" => "",
+                "permissions" => [],
+                "include_in_regression" => false,
+                "steps" => ["Verify filtering."],
+              },
+            ],
           },
         ]
       )
@@ -169,6 +207,16 @@ RSpec.describe AcceptanceCriteriaParser do
           { "feature_areas" => [], "regression_tests" => [] }.to_json
         )
       end.to raise_error(RuntimeError, /permissions/)
+    end
+
+    it "requires a top-level Subject/Action array" do
+      raw = payload
+      raw["permissions"].delete("subject_actions")
+
+      expect { described_class.new(raw.to_json) }.to raise_error(
+        RuntimeError,
+        /subject_actions/
+      )
     end
 
     it "requires root collection fields to be arrays" do

--- a/agentic-acceptance-criteria/scripts/render_acceptance_criteria.rb
+++ b/agentic-acceptance-criteria/scripts/render_acceptance_criteria.rb
@@ -6,13 +6,11 @@ require_relative "acceptance_criteria_parser"
 begin
   json_path = ENV.fetch("ACCEPTANCE_CRITERIA_JSON_PATH")
   comment_path = ENV.fetch("ACCEPTANCE_CRITERIA_COMMENT_PATH")
-  pull_request_number = ENV.fetch("PULL_REQUEST_NUMBER")
   pull_request_title = ENV.fetch("PULL_REQUEST_TITLE", "")
 
   parsed = AcceptanceCriteriaParser.parse_file(json_path)
   comment = AcceptanceCriteriaFormatter.new(
     parsed: parsed,
-    pull_request_number: pull_request_number,
     pull_request_title: pull_request_title
   ).render
 

--- a/agentic-acceptance-criteria/scripts/render_acceptance_criteria.rb
+++ b/agentic-acceptance-criteria/scripts/render_acceptance_criteria.rb
@@ -14,7 +14,7 @@ begin
     pull_request_title: pull_request_title
   ).render
 
-  File.write(comment_path, comment)
+  File.write(comment_path, comment, encoding: Encoding::UTF_8)
   warn "[acceptance_criteria] Rendered #{comment_path}"
 rescue JSON::ParserError => e
   warn "Failed to parse acceptance-criteria JSON: #{e.message}"

--- a/agentic-acceptance-criteria/scripts/render_acceptance_criteria_spec.rb
+++ b/agentic-acceptance-criteria/scripts/render_acceptance_criteria_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe "render_acceptance_criteria.rb" do
     env = {
       "ACCEPTANCE_CRITERIA_JSON_PATH" => json_path,
       "ACCEPTANCE_CRITERIA_COMMENT_PATH" => comment_path,
-      "PULL_REQUEST_NUMBER" => "42",
       "PULL_REQUEST_TITLE" => "Search migration",
     }
     stdout, stderr, status = Open3.capture3(env, RbConfig.ruby, script)
@@ -33,7 +32,11 @@ RSpec.describe "render_acceptance_criteria.rb" do
 
   it "renders a provider response to the requested comment path" do
     payload = {
-      "permissions" => { "required" => "no", "roles" => [] },
+      "permissions" => {
+        "required" => "no",
+        "roles" => [],
+        "subject_actions" => [],
+      },
       "feature_areas" => [],
       "regression_tests" => [],
     }
@@ -48,7 +51,7 @@ RSpec.describe "render_acceptance_criteria.rb" do
       expect(stdout).to be_empty
       expect(stderr).to include("[acceptance_criteria] Rendered")
       expect(File.read(comment_path)).to include(
-        "## ✅ Test Plan: PR #42 — Search migration"
+        "## ✅ Test Plan: Search migration"
       )
     end
   end

--- a/agentic-acceptance-criteria/scripts/render_acceptance_criteria_spec.rb
+++ b/agentic-acceptance-criteria/scripts/render_acceptance_criteria_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "render_acceptance_criteria.rb" do
       expect(status).to be_success
       expect(stdout).to be_empty
       expect(stderr).to include("[acceptance_criteria] Rendered")
-      expect(File.read(comment_path)).to include(
+      expect(File.read(comment_path, encoding: Encoding::UTF_8)).to include(
         "## ✅ Test Plan: Search migration"
       )
     end

--- a/docs/agentic-acceptance-criteria-plan.md
+++ b/docs/agentic-acceptance-criteria-plan.md
@@ -49,7 +49,10 @@ The prompt will instruct Cursor to:
 
 - Write for non-technical manual QA testers.
 - Cover all changed application behavior and plausible adjacent regressions.
-- Identify roles, permissions, validation paths, error behavior, state transitions, and differing access configurations only when supported by the diff or repository.
+- Identify roles and exact permission Subject/Action pairs, along with validation paths, error behavior, state transitions, and differing access configurations, only when supported by the diff or repository.
+- Group scenarios primarily by identical or similar tester paths and secondarily by product domain.
+- Include the landing-page relative URL and applicable Subject/Action pairs on every functional case.
+- Mark functional cases that also provide regression coverage so Regression Testing can reference only their generated identifiers.
 - Express each scenario as executable tester actions followed by observable `Verify...` outcomes.
 - Avoid implementation details, code terminology, filenames, classes, migrations, and automated-test instructions.
 - Avoid inventing application behavior or access requirements.
@@ -62,16 +65,30 @@ The response schema will be:
 {
   "permissions": {
     "required": "yes | no | not_identified",
-    "roles": ["Role or access configuration"]
+    "roles": ["Role or access configuration"],
+    "subject_actions": [
+      {
+        "subject": "ReminderCall",
+        "action": "read"
+      }
+    ]
   },
   "feature_areas": [
     {
-      "name": "Feature or page name",
-      "location": "Optional application location",
+      "test_path": "View and filter reminder call history",
+      "domain": "Contact Center",
       "code": "RCH",
       "scenarios": [
         {
           "title": "Page load/default results",
+          "landing_page": "/contact_center/reminder_calls",
+          "permissions": [
+            {
+              "subject": "ReminderCall",
+              "action": "read"
+            }
+          ],
+          "include_in_regression": true,
           "steps": [
             "Open the feature.",
             "Verify the page loads and displays the expected default results."
@@ -94,9 +111,10 @@ The parser and formatter will:
 - Recover valid JSON when Cursor incorrectly adds prose or code fences.
 - Require the documented root object and arrays.
 - Normalize whitespace and discard empty entries.
-- Deduplicate identical roles, steps, and regression checks while retaining their original order.
+- Deduplicate identical roles, Subject/Action pairs, steps, and regression checks while retaining their original order.
 - Validate feature codes as short uppercase identifiers; use `AC` when a supplied code is absent or invalid.
 - Assign scenario numbers deterministically in output order, such as `RCH-1` and `RCH-2`.
+- List generated identifiers for functional cases that also apply to Regression Testing without duplicating their full text.
 - Render an explicit no-QA result when no feature scenarios or regressions are found.
 
 ## Generated PR Comment
@@ -104,7 +122,7 @@ The parser and formatter will:
 Only the example beginning at line 68 (`✅ Test Plan`) informs this format. The preceding system story, launch plan, and original acceptance-criteria prose are excluded.
 
 ```markdown
-## ✅ Test Plan: PR #<number> — <PR title>
+## ✅ Test Plan: <PR title>
 
 ---
 
@@ -114,20 +132,27 @@ Only the example beginning at line 68 (`✅ Test Plan`) informs this format. The
 - **Roles to Test:**
   - <Role, permission set, or access configuration>
   - <Additional role when behavior varies by access>
+- **Permission Subjects / Actions:**
+  - **Subject:** `<exact Subject>`; **Action:** `<exact Action>`
 
 ---
 
 ### Functional / Features to Test
 
-#### <Feature or page name> — `<application location, when identifiable>`
+#### <Shared tester path> — <secondary product domain, when identifiable>
 
 - **<AREA>-1 — <Scenario name>**
+  - **Landing Page:** `/<relative URL>`
+  - **Permissions:**
+    - **Subject:** `<exact Subject>`; **Action:** `<exact Action>`
   - <Setup or action written for a non-technical tester>
   - <Next action>
   - Verify <observable result>.
   - Verify <relevant error, boundary, or alternate outcome>.
 
 - **<AREA>-2 — <Scenario name>**
+  - **Landing Page:** `/<relative URL>`
+  - **Permissions:** <No special permission required or not identified>
   - <Setup or action>
   - Verify <observable result>.
 
@@ -135,6 +160,7 @@ Only the example beginning at line 68 (`✅ Test Plan`) informs this format. The
 
 ### Regression Testing
 
+- **Applicable Functional Cases:** <AREA>-1, <AREA>-2
 - Verify <existing related behavior remains unchanged>.
 - Verify <neighboring workflow or page still works>.
 - Verify <authorization or data visibility remains correct>.
@@ -198,9 +224,10 @@ Merging the shared action first is the safest sequence. It prevents `nitro-web` 
 - Parse valid structured output.
 - Recover JSON from fenced or prefixed output.
 - Reject malformed roots and invalid field types.
-- Normalize and deduplicate roles, steps, and regression checks.
+- Normalize and deduplicate roles, Subject/Action pairs, steps, and regression checks.
 - Generate fallback `AC` scenario identifiers.
-- Render the exact Markdown hierarchy and numbering.
+- Render the exact Markdown hierarchy, landing-page URLs, per-case permissions, and numbering.
+- Reference regression-applicable functional identifiers without repeating their full scenarios.
 - Render the explicit no-manual-QA result.
 - Preserve the last successful comment when generation or parsing fails.
 


### PR DESCRIPTION
## Summary

Refines the agentic acceptance-criteria workflow based on feedback from the `nitro-web` beta. Generated plans now provide more actionable permission and navigation details, organize functional coverage around tester workflows, and reference applicable functional cases from regression testing without duplicating content.

## What changed

- Removed the auto-linked PR number from the test-plan heading while retaining the PR title.
- Added exact permission Subject/Action pairs:
  - At the overall plan level.
  - On each applicable functional case.
- Added a landing-page relative URL to every functional case.
- Changed functional grouping to prioritize identical or similar tester paths, with product domain used as secondary context.
- Added deterministic regression references:
  - Functional cases can be marked as providing regression coverage.
  - Regression Testing lists their generated identifiers, such as `RCH-1`, without repeating the complete scenarios.
- Updated parsing and formatting to normalize and deduplicate Subject/Action pairs while preserving stable functional identifiers.
- Updated the prompt contract, action wiring, documentation, and test coverage for the new output schema.
- Made provider JSON reading and Markdown output explicitly UTF-8 so rendering works under US-ASCII shell locales.

## Validation

- [x] Acceptance-criteria parser specs — 12 examples, 0 failures
- [x] Acceptance-criteria formatter specs — 6 examples, 0 failures
- [x] Command-line renderer specs — 2 examples, 0 failures
- [x] All 20 examples pass with `LANG=C` and `LC_ALL=C`
- [x] Ruby syntax checks pass
- [x] Composite-action YAML parses successfully
- [x] `git diff --check` passes
