### PR TITLE
[HFH] More Agentic Acceptance Criteria tweaks

### DIFF
--- a/agentic-acceptance-criteria/README.md
+++ b/agentic-acceptance-criteria/README.md
@@ -4,8 +4,8 @@ Generates a structured manual QA plan from a pull request's **merge-base diff** 
 
 The generated plan is written for non-technical testers and contains:
 
-- Permissions and roles to test, including exact permission Subject/Action pairs.
-- Test-path-oriented scenarios with landing-page relative URLs and per-case permissions.
+- Permissions and roles to test, including the Subject/Action labels shown in the application UI and direct permission changes made by the PR.
+- Test-path-oriented scenarios with landing-page relative URLs, per-case permissions, and coverage for every distinctly affected reachable page.
 - Targeted regression testing that references applicable functional case identifiers.
 
 ## What it does
@@ -122,7 +122,7 @@ This workflow does not listen for PR opening, ready-for-review, or synchronizati
 
 ## Generation context
 
-The provider receives `pr.diff`, read-only access to repository files for context, and `additional-prompt` when supplied. It groups functional cases by similar tester paths before using product domain as a secondary classification. The PR title is used only by the deterministic formatter's heading, and the PR title and description are not included in the provider prompt.
+The provider receives `pr.diff`, read-only access to repository files for context, and `additional-prompt` when supplied. It inventories every distinctly affected reachable page before adding depth, groups only behaviorally uniform tester paths, and uses product domain as a secondary classification. It also calls out permission definitions and direct permission lookups/checks added or modified by the diff. In Consent applications, it resolves each permission through the matching action, emits `action.subject.label` as the Subject, and titleizes the action key as the UI does. The PR title is used only by the deterministic formatter's heading, and the PR title and description are not included in the provider prompt.
 
 ## Cursor permissions
 

--- a/agentic-acceptance-criteria/prompts/acceptance_criteria.md
+++ b/agentic-acceptance-criteria/prompts/acceptance_criteria.md
@@ -17,11 +17,13 @@ Create a complete, risk-based manual QA plan for the application behavior change
 - Write for a tester who understands the product but does not need to understand the implementation.
 - Cover all changed user-visible behavior and adjacent regression paths plausibly affected by the change.
 - Identify permissions, roles, validation paths, errors, state transitions, alternate access configurations, and boundary cases only when the diff or repository supports them.
-- For every identified permission, report the exact authorization Subject and Action used by the application. In repositories that use Consent, derive these values from the Consent permission definitions and authorization checks. A Subject/Action pair is required in addition to a human-facing role or access configuration.
+- For every identified permission, report the Subject and Action exactly as they appear in the application's permissions UI. A Subject/Action pair is required in addition to a human-facing role or access configuration.
+- In repositories that use Consent, first identify the raw subject and action keys from the authorization check. Resolve the matching action with `Consent.find_action(subject_key, action_key)`, use that action's `subject.label` for the Subject, and titleize the action key for the Action as the UI does. Using the matched action is important because one subject key can have multiple `Consent.define` blocks with different labels. Do not use the Ruby class constant as the Subject or Consent's descriptive `action.label` as the Action.
+- Call out permission changes in `permissions.changes` when the diff adds a permission definition, or directly adds, removes, or modifies a permission lookup or authorization check. Describe the change concisely with UI-facing Subject and Action labels, such as `Added permission lookup: Project Items — Edit Comments.` Use an empty array when the diff contains no such permission change.
 - Express scenarios as concrete tester actions followed by observable outcomes beginning with `Verify`.
 - Use product-facing names and navigation locations when they can be identified confidently.
 - Do not mention source files, classes, methods, migrations, code architecture, automated tests, or implementation details.
-- Exact permission Subject and Action identifiers are allowed and required; do not replace them with implementation explanations.
+- UI-facing permission Subject and Action labels are allowed and required; do not replace them with implementation explanations.
 - Do not invent roles, permissions, routes, test data, or behavior.
 - Use empty arrays or `not_identified` when the repository does not provide enough evidence.
 - If the change has no manually testable application behavior, return no feature areas or regression tests.
@@ -32,10 +34,13 @@ Additional instructions supplied with the trigger may prioritize or refine the Q
 
 Organize functional cases by the tester's path through the application, not primarily by product domain.
 
-1. Put cases with identical or substantially similar setup, navigation, actions, and verification flow in the same `feature_areas` entry, even when they touch more than one product domain.
-2. Split cases when the tester follows a materially different path.
-3. Use `domain` only as a secondary classification for a test-path group.
-4. Order test-path groups so identical or similar paths remain adjacent. Use domain only to order groups whose test paths are otherwise unrelated.
+1. Inventory every reachable application page and tester path whose behavior is changed by the diff before adding detailed edge cases.
+2. Every reachable page that is altered in a way that is not behaviorally uniform with the other affected pages must appear in at least one functional scenario. Coverage of shared underlying code or a similar page does not substitute for that page.
+3. Establish breadth first: include concise baseline coverage for every distinctly affected page or path before expanding any one area with variants, boundary cases, or regressions.
+4. Put cases with identical or substantially similar setup, navigation, actions, and observable behavior in the same `feature_areas` entry, even when they touch more than one product domain. Do not group pages whose resulting behavior differs.
+5. Split cases when the tester follows a materially different path or must verify page-specific behavior.
+6. Use `domain` only as a secondary classification for a test-path group.
+7. Order test-path groups so identical or similar paths remain adjacent. Use domain only to order groups whose test paths are otherwise unrelated.
 
 Each scenario must identify the relative URL of the landing page where its test begins. Use a path beginning with `/` and omit the scheme and host. Use an empty string only when the repository does not provide enough evidence to identify the route.
 
@@ -51,10 +56,13 @@ Use exactly this shape:
   "permissions": {
     "required": "not_identified",
     "roles": ["Role or access configuration"],
+    "changes": [
+      "Added permission lookup: Project Items — Edit Comments."
+    ],
     "subject_actions": [
       {
-        "subject": "Exact permission Subject",
-        "action": "Exact permission Action"
+        "subject": "Permission Subject label shown in the UI",
+        "action": "Titleized permission Action shown in the UI"
       }
     ]
   },
@@ -69,8 +77,8 @@ Use exactly this shape:
           "landing_page": "/relative/path/where/testing/begins",
           "permissions": [
             {
-              "subject": "Exact permission Subject required by this case",
-              "action": "Exact permission Action required by this case"
+              "subject": "Permission Subject label shown in the UI for this case",
+              "action": "Titleized permission Action shown in the UI for this case"
             }
           ],
           "include_in_regression": false,
@@ -94,10 +102,12 @@ Rules for the JSON:
 
 - `permissions`, `feature_areas`, and `regression_tests` are required.
 - `permissions.required` must be exactly `yes`, `no`, or `not_identified`.
-- `permissions.roles` and `permissions.subject_actions` are required arrays.
-- Every `test_path`, `domain`, `code`, `title`, `landing_page`, step, role, permission Subject, permission Action, regression text, and detail must be a string.
+- `permissions.roles`, `permissions.changes`, and `permissions.subject_actions` are required arrays.
+- Every `test_path`, `domain`, `code`, `title`, `landing_page`, step, role, UI-facing permission Subject, UI-facing permission Action, regression text, and detail must be a string.
 - Every scenario must include a `permissions` array and a boolean `include_in_regression`.
 - Include every Subject/Action pair used by the plan in `permissions.subject_actions`, and repeat the applicable pair or pairs in each scenario's `permissions`.
+- Include a concise `permissions.changes` entry for every permission definition or direct permission lookup/check added, removed, or modified by the diff. Do not list unchanged permissions there.
+- Before returning JSON, verify that every distinctly affected reachable page or tester path is represented by at least one scenario.
 - Every scenario must contain at least one action and one observable verification.
 - Keep steps concise and independently executable.
 - Do not number scenarios; the formatter assigns stable identifiers.

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter.rb
@@ -41,10 +41,16 @@ private
 
   def permissions_section
     lines = [
-      "### Permissions / Roles",
+      "## Permissions / Roles",
       "",
       "- **Required Permissions:** #{PERMISSION_LABELS.fetch(@parsed.permissions.fetch("required"))}",
     ]
+
+    permission_changes = @parsed.permissions.fetch("changes")
+    unless permission_changes.empty?
+      lines << "- **Permission Changes in This PR:**"
+      permission_changes.each { |change| lines << "  - #{change.delete("`")}" }
+    end
 
     roles = @parsed.permissions.fetch("roles")
     if roles.empty?
@@ -61,14 +67,14 @@ private
       lines << "- **Permission Subjects / Actions:** #{subject_actions_message}"
     else
       lines << "- **Permission Subjects / Actions:**"
-      subject_actions.each { |permission| lines << permission_line(permission, "  ") }
+      subject_actions.each { |permission| lines << "  - #{permission_display(permission)}" }
     end
 
     lines.join("\n")
   end
 
   def features_section
-    lines = ["### Functional / Features to Test", ""]
+    lines = ["## Functional / Features to Test", ""]
 
     if @parsed.feature_areas.empty?
       lines << "- #{NO_MANUAL_QA_MESSAGE}"
@@ -83,10 +89,12 @@ private
       area.fetch("scenarios").each_with_index do |scenario, scenario_index|
         lines << "" unless scenario_index.zero?
         identifier = @case_identifiers.fetch(scenario.object_id)
-        lines << "- **#{identifier} — #{scenario.fetch("title")}**"
-        lines << "  - **Landing Page:** #{format_landing_page(scenario.fetch("landing_page"))}"
-        lines.concat(scenario_permission_lines(scenario))
-        scenario.fetch("steps").each { |step| lines << "  - #{step}" }
+        lines << "#### #{identifier} — #{scenario.fetch("title")}"
+        lines << ""
+        lines << "**Landing Page:** #{format_landing_page(scenario.fetch("landing_page"))}  "
+        lines << "**Permissions:** #{scenario_permissions(scenario)}"
+        lines << ""
+        scenario.fetch("steps").each { |step| lines << "- #{step}" }
       end
     end
 
@@ -96,11 +104,11 @@ private
   def feature_heading(area)
     domain = area.fetch("domain")
     suffix = domain.empty? ? "" : " — #{domain}"
-    "#### #{area.fetch("test_path")}#{suffix}"
+    "### #{area.fetch("test_path")}#{suffix}"
   end
 
   def regression_section
-    lines = ["### Regression Testing", ""]
+    lines = ["## Regression Testing", ""]
     applicable_cases = regression_case_identifiers
 
     if applicable_cases.empty? && @parsed.regression_tests.empty?
@@ -140,28 +148,24 @@ private
     end
   end
 
-  def scenario_permission_lines(scenario)
+  def scenario_permissions(scenario)
     permissions = scenario.fetch("permissions")
     if permissions.empty?
-      message = @parsed.permissions.fetch("required") == "no" ? "No special permission required." : "Not identified for this case."
-      return ["  - **Permissions:** #{message}"]
+      return @parsed.permissions.fetch("required") == "no" ? "No special permission required." : "Not identified for this case."
     end
 
-    [
-      "  - **Permissions:**",
-      *permissions.map { |permission| permission_line(permission, "    ") },
-    ]
+    permissions.map { |permission| permission_display(permission) }.join("; ")
   end
 
-  def permission_line(permission, indentation)
+  def permission_display(permission)
     subject = permission.fetch("subject").delete("`")
     action = permission.fetch("action").delete("`")
-    "#{indentation}- **Subject:** `#{subject}`; **Action:** `#{action}`"
+    "#{subject} — #{action}"
   end
 
   def format_landing_page(value)
     landing_page = value.delete("`")
-    landing_page.empty? ? "Not identified from this change." : "`#{landing_page}`"
+    landing_page.empty? ? "Not identified from this change." : landing_page
   end
 
   def normalize_text(value)

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter.rb
@@ -118,6 +118,7 @@ private
 
     unless applicable_cases.empty?
       lines << "- **Applicable Functional Cases:** #{applicable_cases.join(", ")}"
+      lines << "" unless @parsed.regression_tests.empty?
     end
 
     @parsed.regression_tests.each do |test|

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter_spec.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe AcceptanceCriteriaFormatter do
       ## Regression Testing
 
       - **Applicable Functional Cases:** RCH-1
+
       - Verify existing links still work.
         - Project links.
         - Recording links.

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter_spec.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_formatter_spec.rb
@@ -29,9 +29,10 @@ RSpec.describe AcceptanceCriteriaFormatter do
       "permissions" => {
         "required" => "yes",
         "roles" => ["User with Reminder Call History read access"],
+        "changes" => ["Added permission lookup: Reminder Calls — Read."],
         "subject_actions" => [
-          { "subject" => "ReminderCall", "action" => "read" },
-          { "subject" => "Project", "action" => "read" },
+          { "subject" => "Reminder Calls", "action" => "Read" },
+          { "subject" => "Projects", "action" => "Read" },
         ],
       },
       "feature_areas" => [
@@ -44,7 +45,7 @@ RSpec.describe AcceptanceCriteriaFormatter do
               "title" => "Page load/default results",
               "landing_page" => "/contact_center/reminder_calls",
               "permissions" => [
-                { "subject" => "ReminderCall", "action" => "read" },
+                { "subject" => "Reminder Calls", "action" => "Read" },
               ],
               "include_in_regression" => true,
               "steps" => [
@@ -56,8 +57,8 @@ RSpec.describe AcceptanceCriteriaFormatter do
               "title" => "Project filter",
               "landing_page" => "/contact_center/reminder_calls",
               "permissions" => [
-                { "subject" => "ReminderCall", "action" => "read" },
-                { "subject" => "Project", "action" => "read" },
+                { "subject" => "Reminder Calls", "action" => "Read" },
+                { "subject" => "Projects", "action" => "Read" },
               ],
               "include_in_regression" => false,
               "steps" => [
@@ -83,39 +84,42 @@ RSpec.describe AcceptanceCriteriaFormatter do
 
       ---
 
-      ### Permissions / Roles
+      ## Permissions / Roles
 
       - **Required Permissions:** Yes
+      - **Permission Changes in This PR:**
+        - Added permission lookup: Reminder Calls — Read.
       - **Roles to Test:**
         - User with Reminder Call History read access
       - **Permission Subjects / Actions:**
-        - **Subject:** `ReminderCall`; **Action:** `read`
-        - **Subject:** `Project`; **Action:** `read`
+        - Reminder Calls — Read
+        - Projects — Read
 
       ---
 
-      ### Functional / Features to Test
+      ## Functional / Features to Test
 
-      #### View and filter reminder call history — Contact Center
+      ### View and filter reminder call history — Contact Center
 
-      - **RCH-1 — Page load/default results**
-        - **Landing Page:** `/contact_center/reminder_calls`
-        - **Permissions:**
-          - **Subject:** `ReminderCall`; **Action:** `read`
-        - Open Reminder Call History.
-        - Verify the default results display.
+      #### RCH-1 — Page load/default results
 
-      - **RCH-2 — Project filter**
-        - **Landing Page:** `/contact_center/reminder_calls`
-        - **Permissions:**
-          - **Subject:** `ReminderCall`; **Action:** `read`
-          - **Subject:** `Project`; **Action:** `read`
-        - Filter by a project number prefix.
-        - Verify unrelated projects are removed.
+      **Landing Page:** /contact_center/reminder_calls#{'  '}
+      **Permissions:** Reminder Calls — Read
+
+      - Open Reminder Call History.
+      - Verify the default results display.
+
+      #### RCH-2 — Project filter
+
+      **Landing Page:** /contact_center/reminder_calls#{'  '}
+      **Permissions:** Reminder Calls — Read; Projects — Read
+
+      - Filter by a project number prefix.
+      - Verify unrelated projects are removed.
 
       ---
 
-      ### Regression Testing
+      ## Regression Testing
 
       - **Applicable Functional Cases:** RCH-1
       - Verify existing links still work.
@@ -141,7 +145,7 @@ RSpec.describe AcceptanceCriteriaFormatter do
     }
     payload["feature_areas"] << second_area
 
-    expect(render(payload)).to include("**RCH-3 — Dashboard navigation**")
+    expect(render(payload)).to include("#### RCH-3 — Dashboard navigation")
   end
 
   it "renders explicit fallbacks when no manual QA is identified" do
@@ -149,6 +153,7 @@ RSpec.describe AcceptanceCriteriaFormatter do
       "permissions" => {
         "required" => "not_identified",
         "roles" => [],
+        "changes" => [],
         "subject_actions" => [],
       },
       "feature_areas" => [],
@@ -170,6 +175,7 @@ RSpec.describe AcceptanceCriteriaFormatter do
       "permissions" => {
         "required" => "no",
         "roles" => [],
+        "changes" => [],
         "subject_actions" => [],
       },
       "feature_areas" => [],
@@ -184,23 +190,75 @@ RSpec.describe AcceptanceCriteriaFormatter do
     )
   end
 
-  it "normalizes the PR title without linking the PR and removes backticks from identifiers" do
+  it "renders per-case permission fallbacks as standalone metadata" do
+    payload["feature_areas"].first["scenarios"].first["permissions"] = []
+
+    expect(render(payload)).to include(
+      "**Landing Page:** /contact_center/reminder_calls  \n**Permissions:** Not identified for this case.\n\n- Open Reminder Call History."
+    )
+
+    payload["permissions"]["required"] = "no"
+
+    expect(render(payload)).to include(
+      "**Permissions:** No special permission required.\n\n- Open Reminder Call History."
+    )
+  end
+
+  it "renders Consent permissions with the matching UI subject and titleized action" do
+    payload["permissions"]["subject_actions"] = [
+      { "subject" => "Project Items", "action" => "Edit Comments" },
+      { "subject" => "Projects", "action" => "Edit Items For Closed Project" },
+    ]
+    payload["feature_areas"].first["scenarios"].first["permissions"] = [
+      { "subject" => "Project Items", "action" => "Edit Comments" },
+    ]
+
+    output = render(payload)
+
+    expect(output).to include("- Project Items — Edit Comments")
+    expect(output).to include("- Projects — Edit Items For Closed Project")
+    expect(output).to include("**Permissions:** Project Items — Edit Comments")
+    expect(output).not_to include("ProjectItem")
+    expect(output).not_to include("edit_comments")
+  end
+
+  it "calls out permission changes and removes backticks from their text" do
+    payload["permissions"]["changes"] = [
+      "Added permission: `Project Items` — `Edit Comments`.",
+      "Modified permission lookup: Projects — Edit Items For Closed Project.",
+    ]
+
+    output = render(payload)
+
+    expect(output).to include(<<~MARKDOWN.chomp)
+      - **Permission Changes in This PR:**
+        - Added permission: Project Items — Edit Comments.
+        - Modified permission lookup: Projects — Edit Items For Closed Project.
+    MARKDOWN
+  end
+
+  it "normalizes the PR title and removes backticks from paths and permission labels" do
     payload["feature_areas"].first["scenarios"].first["landing_page"] = "/`unsafe`"
-    payload["permissions"]["subject_actions"].first["subject"] = "`ReminderCall`"
+    payload["permissions"]["subject_actions"].first["subject"] = "`Reminder Calls`"
+    payload["permissions"]["subject_actions"].first["action"] = "`Read`"
+    payload["feature_areas"].first["scenarios"].first["permissions"].first["subject"] = "`Reminder Calls`"
+    payload["feature_areas"].first["scenarios"].first["permissions"].first["action"] = "`Read`"
 
     output = render(payload, title: "  Search\nmigration  ")
 
     expect(output).to start_with("## ✅ Test Plan: Search migration")
     expect(output).not_to include("PR #")
-    expect(output).to include("`/unsafe`")
-    expect(output).to include("**Subject:** `ReminderCall`")
+    expect(output).to include("**Landing Page:** /unsafe")
+    expect(output).to include("- Reminder Calls — Read")
+    expect(output).to include("**Permissions:** Reminder Calls — Read")
+    expect(output).not_to include("`")
   end
 
   it "lists only functional identifiers when regressions are fully covered by functional cases" do
     payload["feature_areas"].first["scenarios"].last["include_in_regression"] = true
     payload["regression_tests"] = []
 
-    regression_section = render(payload).split("### Regression Testing", 2).last
+    regression_section = render(payload).split("## Regression Testing", 2).last
 
     expect(regression_section).to include("**Applicable Functional Cases:** RCH-1, RCH-2")
     expect(regression_section).not_to include("Page load/default results")

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_parser.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_parser.rb
@@ -58,6 +58,9 @@ private
     unless @payload.dig("permissions", "subject_actions").is_a?(Array)
       raise 'Acceptance-criteria permissions must include a "subject_actions" array'
     end
+    unless @payload.dig("permissions", "changes").is_a?(Array)
+      raise 'Acceptance-criteria permissions must include a "changes" array'
+    end
     raise 'Acceptance-criteria JSON must include a "feature_areas" array' unless @payload["feature_areas"].is_a?(Array)
     unless @payload["regression_tests"].is_a?(Array)
       raise 'Acceptance-criteria JSON must include a "regression_tests" array'
@@ -73,6 +76,7 @@ private
       "required" => required,
       "roles" => unique_strings(raw.fetch("roles")),
       "subject_actions" => permission_pairs(raw.fetch("subject_actions")),
+      "changes" => unique_strings(raw.fetch("changes")),
     }
   end
 

--- a/agentic-acceptance-criteria/scripts/acceptance_criteria_parser_spec.rb
+++ b/agentic-acceptance-criteria/scripts/acceptance_criteria_parser_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe AcceptanceCriteriaParser do
       "permissions" => {
         "required" => "yes",
         "roles" => ["Dispatcher"],
+        "changes" => [],
         "subject_actions" => [
-          { "subject" => "ReminderCall", "action" => "read" },
+          { "subject" => "Reminder Calls", "action" => "Read" },
         ],
       },
       "feature_areas" => [],
@@ -28,14 +29,19 @@ RSpec.describe AcceptanceCriteriaParser do
   end
 
   describe "#permissions" do
-    it "normalizes permission values and deduplicates roles and Subject/Action pairs" do
+    it "normalizes and deduplicates permission values, changes, roles, and Subject/Action pairs" do
       raw = payload(
         "permissions" => {
           "required" => "Not Identified",
           "roles" => ["  Dispatcher\nwith access  ", "Dispatcher with access", "", nil],
+          "changes" => [
+            " Added permission lookup: Reminder Calls — Read. ",
+            "Added permission lookup: Reminder Calls — Read.",
+            "",
+          ],
           "subject_actions" => [
-            { "subject" => " ReminderCall ", "action" => " read " },
-            { "subject" => "ReminderCall", "action" => "read" },
+            { "subject" => " Reminder Calls ", "action" => " Read " },
+            { "subject" => "Reminder Calls", "action" => "Read" },
             { "subject" => "", "action" => "update" },
             "invalid",
           ],
@@ -47,8 +53,9 @@ RSpec.describe AcceptanceCriteriaParser do
       expect(parsed.permissions).to eq(
         "required" => "not_identified",
         "roles" => ["Dispatcher with access"],
+        "changes" => ["Added permission lookup: Reminder Calls — Read."],
         "subject_actions" => [
-          { "subject" => "ReminderCall", "action" => "read" },
+          { "subject" => "Reminder Calls", "action" => "Read" },
         ]
       )
     end
@@ -58,6 +65,7 @@ RSpec.describe AcceptanceCriteriaParser do
         "permissions" => {
           "required" => "maybe",
           "roles" => [],
+          "changes" => [],
           "subject_actions" => [],
         }
       )
@@ -78,8 +86,8 @@ RSpec.describe AcceptanceCriteriaParser do
                 "title" => " Page load ",
                 "landing_page" => " /contact_center/reminder_calls ",
                 "permissions" => [
-                  { "subject" => " ReminderCall ", "action" => " read " },
-                  { "subject" => "ReminderCall", "action" => "read" },
+                  { "subject" => " Reminder Calls ", "action" => " Read " },
+                  { "subject" => "Reminder Calls", "action" => "Read" },
                 ],
                 "include_in_regression" => true,
                 "steps" => [
@@ -114,7 +122,7 @@ RSpec.describe AcceptanceCriteriaParser do
                 "title" => "Page load",
                 "landing_page" => "/contact_center/reminder_calls",
                 "permissions" => [
-                  { "subject" => "ReminderCall", "action" => "read" },
+                  { "subject" => "Reminder Calls", "action" => "Read" },
                 ],
                 "include_in_regression" => true,
                 "steps" => ["Open the page.", "Verify default results."],
@@ -216,6 +224,16 @@ RSpec.describe AcceptanceCriteriaParser do
       expect { described_class.new(raw.to_json) }.to raise_error(
         RuntimeError,
         /subject_actions/
+      )
+    end
+
+    it "requires a top-level permission changes array" do
+      raw = payload
+      raw["permissions"].delete("changes")
+
+      expect { described_class.new(raw.to_json) }.to raise_error(
+        RuntimeError,
+        /changes/
       )
     end
 

--- a/agentic-acceptance-criteria/scripts/render_acceptance_criteria_spec.rb
+++ b/agentic-acceptance-criteria/scripts/render_acceptance_criteria_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "render_acceptance_criteria.rb" do
       "permissions" => {
         "required" => "no",
         "roles" => [],
+        "changes" => [],
         "subject_actions" => [],
       },
       "feature_areas" => [],

--- a/docs/agentic-acceptance-criteria-plan.md
+++ b/docs/agentic-acceptance-criteria-plan.md
@@ -172,6 +172,7 @@ Only the example beginning at line 68 (`✅ Test Plan`) informs this format. The
 ## Regression Testing
 
 - **Applicable Functional Cases:** <AREA>-1, <AREA>-2
+
 - Verify <existing related behavior remains unchanged>.
 - Verify <neighboring workflow or page still works>.
 - Verify <authorization or data visibility remains correct>.

--- a/docs/agentic-acceptance-criteria-plan.md
+++ b/docs/agentic-acceptance-criteria-plan.md
@@ -49,8 +49,11 @@ The prompt will instruct Cursor to:
 
 - Write for non-technical manual QA testers.
 - Cover all changed application behavior and plausible adjacent regressions.
-- Identify roles and exact permission Subject/Action pairs, along with validation paths, error behavior, state transitions, and differing access configurations, only when supported by the diff or repository.
-- Group scenarios primarily by identical or similar tester paths and secondarily by product domain.
+- Identify roles and UI-facing permission Subject/Action pairs, along with validation paths, error behavior, state transitions, and differing access configurations, only when supported by the diff or repository.
+- In Consent applications, resolve the matching action with `Consent.find_action(subject_key, action_key)`, use `action.subject.label` for the Subject, and titleize the action key for the Action. Do not use the Ruby class constant or Consent's descriptive action label.
+- Call out permission definitions and direct permission lookups/checks added, removed, or modified by the diff.
+- Inventory every distinctly affected reachable page before adding depth; each page whose changed behavior is not uniform with the others must have functional coverage.
+- Group scenarios primarily by behaviorally uniform tester paths and secondarily by product domain.
 - Include the landing-page relative URL and applicable Subject/Action pairs on every functional case.
 - Mark functional cases that also provide regression coverage so Regression Testing can reference only their generated identifiers.
 - Express each scenario as executable tester actions followed by observable `Verify...` outcomes.
@@ -66,10 +69,13 @@ The response schema will be:
   "permissions": {
     "required": "yes | no | not_identified",
     "roles": ["Role or access configuration"],
+    "changes": [
+      "Added permission lookup: Reminder Calls — Read."
+    ],
     "subject_actions": [
       {
-        "subject": "ReminderCall",
-        "action": "read"
+        "subject": "Reminder Calls",
+        "action": "Read"
       }
     ]
   },
@@ -84,8 +90,8 @@ The response schema will be:
           "landing_page": "/contact_center/reminder_calls",
           "permissions": [
             {
-              "subject": "ReminderCall",
-              "action": "read"
+              "subject": "Reminder Calls",
+              "action": "Read"
             }
           ],
           "include_in_regression": true,
@@ -111,7 +117,7 @@ The parser and formatter will:
 - Recover valid JSON when Cursor incorrectly adds prose or code fences.
 - Require the documented root object and arrays.
 - Normalize whitespace and discard empty entries.
-- Deduplicate identical roles, Subject/Action pairs, steps, and regression checks while retaining their original order.
+- Deduplicate identical roles, permission-change notes, Subject/Action pairs, steps, and regression checks while retaining their original order.
 - Validate feature codes as short uppercase identifiers; use `AC` when a supplied code is absent or invalid.
 - Assign scenario numbers deterministically in output order, such as `RCH-1` and `RCH-2`.
 - List generated identifiers for functional cases that also apply to Regression Testing without duplicating their full text.
@@ -126,39 +132,44 @@ Only the example beginning at line 68 (`✅ Test Plan`) informs this format. The
 
 ---
 
-### Permissions / Roles
+## Permissions / Roles
 
 - **Required Permissions:** <Yes, No, or Not identified>
+- **Permission Changes in This PR:**
+  - <Added, removed, or modified permission definition or direct lookup/check>
 - **Roles to Test:**
   - <Role, permission set, or access configuration>
   - <Additional role when behavior varies by access>
 - **Permission Subjects / Actions:**
-  - **Subject:** `<exact Subject>`; **Action:** `<exact Action>`
+  - <UI Subject label> — <titleized UI Action>
 
 ---
 
-### Functional / Features to Test
+## Functional / Features to Test
 
-#### <Shared tester path> — <secondary product domain, when identifiable>
+### <Shared tester path> — <secondary product domain, when identifiable>
 
-- **<AREA>-1 — <Scenario name>**
-  - **Landing Page:** `/<relative URL>`
-  - **Permissions:**
-    - **Subject:** `<exact Subject>`; **Action:** `<exact Action>`
-  - <Setup or action written for a non-technical tester>
-  - <Next action>
-  - Verify <observable result>.
-  - Verify <relevant error, boundary, or alternate outcome>.
+#### <AREA>-1 — <Scenario name>
 
-- **<AREA>-2 — <Scenario name>**
-  - **Landing Page:** `/<relative URL>`
-  - **Permissions:** <No special permission required or not identified>
-  - <Setup or action>
-  - Verify <observable result>.
+**Landing Page:** /<relative URL>
+**Permissions:** <UI Subject label> — <titleized UI Action>; <additional permission when needed>
+
+- <Setup or action written for a non-technical tester>
+- <Next action>
+- Verify <observable result>.
+- Verify <relevant error, boundary, or alternate outcome>.
+
+#### <AREA>-2 — <Scenario name>
+
+**Landing Page:** /<relative URL>
+**Permissions:** <No special permission required or not identified>
+
+- <Setup or action>
+- Verify <observable result>.
 
 ---
 
-### Regression Testing
+## Regression Testing
 
 - **Applicable Functional Cases:** <AREA>-1, <AREA>-2
 - Verify <existing related behavior remains unchanged>.
@@ -224,9 +235,10 @@ Merging the shared action first is the safest sequence. It prevents `nitro-web` 
 - Parse valid structured output.
 - Recover JSON from fenced or prefixed output.
 - Reject malformed roots and invalid field types.
-- Normalize and deduplicate roles, Subject/Action pairs, steps, and regression checks.
+- Normalize and deduplicate roles, permission-change notes, Subject/Action pairs, steps, and regression checks.
 - Generate fallback `AC` scenario identifiers.
 - Render the exact Markdown hierarchy, landing-page URLs, per-case permissions, and numbering.
+- Render permission-change callouts and ensure every distinctly affected reachable page is represented.
 - Reference regression-applicable functional identifiers without repeating their full scenarios.
 - Render the explicit no-manual-QA result.
 - Preserve the last successful comment when generation or parsing fails.


### PR DESCRIPTION
## Summary

Refines the agentic acceptance-criteria workflow based on additional QA feedback. Generated plans now prioritize complete page coverage, use UI-facing permission names, explicitly call out permission changes, and present test metadata in a more compact, copy-friendly format.

## What Changed

- Requires baseline coverage for every distinctly affected reachable page before expanding any single area with edge cases.
- Prevents behaviorally different pages from being grouped solely because they share underlying code.
- Uses Consent’s matching action to resolve the UI-facing subject label and titleizes action keys as Nitro does.
- Adds a required `permissions.changes` array for permission definitions and direct authorization lookups added, removed, or modified by the diff.
- Displays permission-change notes prominently in the top Permissions / Roles section.
- Removes backticks from landing pages and permission displays.
- Promotes section, feature-area, and scenario headings by one level.
- Separates scenarios from their metadata while keeping Landing Page and Permissions tightly grouped.
- Displays multiple scenario permissions on one line.
- Adds spacing between Applicable Functional Cases and additional regression verification checks.
- Updates documentation and examples for the revised JSON contract and Markdown output.

## Validation

- [x] Acceptance-criteria parser specs — 13 examples, 0 failures
- [x] Acceptance-criteria formatter specs — 9 examples, 0 failures
- [x] Command-line renderer specs — 2 examples, 0 failures
- [x] All 24 examples pass under `LANG=C` and `LC_ALL=C`
- [x] Ruby syntax checks pass
- [x] Composite-action YAML parses successfully
- [x] `git diff --check` passes